### PR TITLE
Using six for checking if a variable is a string

### DIFF
--- a/nco/nco.py
+++ b/nco/nco.py
@@ -24,6 +24,7 @@ import re
 import subprocess
 import tempfile
 import random
+import six
 from . import custom
 
 class NCOException(Exception):
@@ -87,7 +88,7 @@ class Nco(object):
 
         inline_cmd = cmd
         if inputs is not None:
-            if isinstance(inputs, str):
+            if isinstance(inputs, six.string_types):
                 inline_cmd.append(inputs)
             else:
                 #we assume it's either a list, a tuple or any iterable.
@@ -150,7 +151,7 @@ class Nco(object):
 
             if options:
                 for o in options:
-                    if isinstance(o,str):
+                    if isinstance(o, six.string_types):
                         cmd.extend(o.split())
                     # only a custom object will have this method - eg the class atted
                     elif hasattr(o, 'prn_option'):
@@ -185,7 +186,7 @@ class Nco(object):
                         cmd.append("--{0}".format(key))
                         if cmd[-1] in (self.DontForcePattern):
                             force = False
-                    elif isinstance(val, str) or \
+                    elif isinstance(val, six.string_types) or \
                             isinstance(val, int) or \
                             isinstance(val, float):
                         cmd.append("--{0}={1}".format(key, val))
@@ -198,7 +199,7 @@ class Nco(object):
                 for key, val in list(self.options.items()):
                     if val and type(val) == bool:
                         cmd.append("--"+key)
-                    elif isinstance(val, str):
+                    elif isinstance(val, six.string_types):
                         cmd.append("--{0}={1}".format(key, val))
                     else:
                         #we assume it's either a list, a tuple or any iterable.
@@ -229,7 +230,7 @@ class Nco(object):
                         raise NCOException(**retvals)
             else:
                 if output:
-                    if isinstance(output, str):
+                    if isinstance(output, six.string_types):
                         cmd.append("--output={0}".format(output))
                     else:
                         # we assume it's an iterable.

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(name='nco',
                    "Topic :: Utilities",
                    "Operating System :: POSIX",
                    "Programming Language :: Python",
-                   ],
+                   ], install_requires=['six']
       )


### PR DESCRIPTION
The package is now doing it as show next:

`isinstance(var, str)`

It works well for python 3.x but fails for unicode strings in python 2.x (you must use basestring in this case).

I have modified all checks to use the six.string_types that will contain the appropriated types for each python version (str for 3.x, basestring for 2.x)

For more details, see http://stackoverflow.com/questions/4843173/how-to-check-if-type-of-a-variable-is-string