### PR TITLE
Now able to provide temporary files when no output files are specified

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,15 +71,15 @@ nco = Nco()
 Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco`.
 
 * Required arguments
-    -  `input` - Input netcdf file name, str
+    -  `input_file` - Input netcdf file name, str
 
 * Optional arguments
 
     -  `output` - `str` or `list` of strings representing input netCDF filenames.  If not provided and operator returns a file (not an array or stdout text), the method will return a temporary file.
-    - `debug` - `bool` or `int`, if less than 0 or True, debug statements will be turned on for NCO and NCOpy (default: `False`)
-    -  `returnCdf` - `bool`, return a netCDF file handle (default: `False`)
-    -  `returnArray` - `str`. return a numpy array of variable name (default: `''`)
-    -  `returnMaArray` - `str`. return a numpy masked array of variable name (default: `''`)
+    -  `debug` - `bool` or `int`, if less than 0 or True, debug statements will be turned on for NCO and NCOpy (default: `False`)
+    -  `return_cdf` - `bool`, return a netCDF file handle (default: `False`)
+    -  `return_array` - `str`. return a numpy array of variable name (default: `''`)
+    -  `return_ma_array` - `str`. return a numpy masked array of variable name (default: `''`)
     -  `options` - `list`, NCO input options, for example `options=['-7', '-L 1']` (default: `[]`)
     -  `Atted` - a wrapper object to be used for ncatted. Atted objects can be included in the options list
     -  `Limit` - a wrapper object for the hyperslab (`-d`) command line option
@@ -92,33 +92,33 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
 *  File information:
 
     ```python
-    ncdump_string = nco.ncdump(input=ifile)
+    ncdump_string = nco.ncdump(input_file=ifile)
     ```
 
 *  Operators with user defined regular output files:
 
     ```python
-    nco.ncra(input=ifile, output=ofile)
+    nco.ncra(input_file=ifile, output=ofile)
     ```
 
 *  Use temporary output files:
 
     ```python
-    temp_ofile = nco.ncrcat(input=ifile)
+    temp_ofile = nco.ncrcat(input_file=ifile)
     ```
 
 *  Set global NCO options:
 
     ```python
-    nco.ncks(input=ifile, output=ofile, options="--netcdf4")
+    nco.ncks(input_file=ifile, output=ofile, options="--netcdf4")
     ```
 
 *  Return multi-dimension arrays:
 
     ```python
-    temperatures = nco.ncra(input=ifile, returnArray=True).variables['T'][:]
-    temperatures = nco.ncra(input=ifile, returnCdf=True).variables['T'][:]
-    temperatures = nco.ncra(input=ifile, returnArray='T')
+    temperatures = nco.ncra(input_file=ifile, return_array=True).variables['T'][:]
+    temperatures = nco.ncra(input_file=ifile, return_cdf=True).variables['T'][:]
+    temperatures = nco.ncra(input_file=ifile, return_array='T')
     ```
 
 * Wrapper Objects
@@ -131,7 +131,7 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
 
     ```
     ncatted -a _FillValue,three_dmn,o,d,-9.91e+33 in.nc
-    nco.ncatted(input="in.nc",options=[c.atted("overwrite","_FillValue","three_dmn",-9.91e+33,'d')])
+    nco.ncatted(input_file="in.nc",options=[c.atted("overwrite","_FillValue","three_dmn",-9.91e+33,'d')])
     ```
 
 ## Tempfile helpers
@@ -140,13 +140,13 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
 absence of a specified output file, `pynco` will create a temporary file to allow the results of the task to be returned to the user.  For example:
 
 ```python
-temperatures = nco.ncra(input=ifile, returnArray='T')
+temperatures = nco.ncra(input_file=ifile, return_array='T')
 ```
 
 is equivalent to:
 
 ```
-temperatures = nco.ncra(input=ifile, output=tempfile.mktemp(), returnArray='T')
+temperatures = nco.ncra(input_file=ifile, output=tempfile.mktemp(), return_array='T')
 ```
 
 
@@ -161,7 +161,7 @@ opt = [
     c.Atted("m", "max", "temperature", 283.01, 'float64'),
     c.Atted("c", "bnds", "time", [0.5, 1.5], 'f')
 ]
-nco.ncatted(input="in.nc", options=opt)
+nco.ncatted(input_file="in.nc", options=opt)
 ```
 
 You can also use keyword arguments in the call so the above options become
@@ -173,7 +173,7 @@ opt = [
     c.Atted(mode="modify", attName="max", varName="temperature", Value=283.01, sType='float64'),
     c.Atted(mode="create", attName="bnds", varName="time", Value=[0.5, 1.5], sType='float32')
 ]
-nco.ncatted(input="in.nc", options=opt)
+nco.ncatted(input_file="in.nc", options=opt)
 ```
 
 #### `Value`
@@ -217,7 +217,7 @@ opt = [
     c.Limit(dmn_name="lev", srd=4)
 ]
 
-nco.ncks(input="in.nc", output="out.nc", options=opt)
+nco.ncks(input_file="in.nc", output="out.nc", options=opt)
 ```
 
 ##  Rename wrapper
@@ -237,7 +237,7 @@ rDict = {
     'p': 'pressure',
     't': 'temperature'
 }
-nco.ncrename(input="in.nc", options=[ c.Rename("variable", rDict) ])
+nco.ncrename(input_file="in.nc", options=[ c.Rename("variable", rDict) ])
 ```
 
 Also equivalent:
@@ -255,7 +255,7 @@ rDict = {
     'lon': 'longitude',
     'lat': 'latitude'
 }
-nco.ncrename(input="in.nc", options=[ c.Rename("d", rDict), c.Rename("v", rDict) ])
+nco.ncrename(input_file="in.nc", options=[ c.Rename("d", rDict), c.Rename("v", rDict) ])
 ```
 
 ## Support, Issues, Bugs, ...

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
     -  `return_cdf` - `bool`, return a netCDF file handle (default: `False`)
     -  `return_array` - `str`. return a numpy array of variable name (default: `''`)
     -  `return_ma_array` - `str`. return a numpy masked array of variable name (default: `''`)
+    -  `use_shell` - `bool`. use shell to execute commands, useful if you need to pass wildcards or other characters in arguments that can be expanded by shell interpretor (default: `False`)
     -  `options` - `list`, NCO input options, for example `options=['-7', '-L 1']` (default: `[]`)
     -  `Atted` - a wrapper object to be used for ncatted. Atted objects can be included in the options list
     -  `Limit` - a wrapper object for the hyperslab (`-d`) command line option

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,15 +71,15 @@ nco = Nco()
 Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco`.
 
 * Required arguments
-    -  `input_file` - Input netcdf file name, str
+    -  `input` - Input netcdf file name, str
 
 * Optional arguments
 
     -  `output` - `str` or `list` of strings representing input netCDF filenames.  If not provided and operator returns a file (not an array or stdout text), the method will return a temporary file.
     -  `debug` - `bool` or `int`, if less than 0 or True, debug statements will be turned on for NCO and NCOpy (default: `False`)
-    -  `return_cdf` - `bool`, return a netCDF file handle (default: `False`)
-    -  `return_array` - `str`. return a numpy array of variable name (default: `''`)
-    -  `return_ma_array` - `str`. return a numpy masked array of variable name (default: `''`)
+    -  `returnCdf` - `bool`, return a netCDF file handle (default: `False`)
+    -  `returnArray` - `str`. return a numpy array of variable name (default: `''`)
+    -  `returnMaArray` - `str`. return a numpy masked array of variable name (default: `''`)
     -  `use_shell` - `bool`. use shell to execute commands, useful if you need to pass wildcards or other characters in arguments that can be expanded by shell interpretor (default: `False`)
     -  `options` - `list`, NCO input options, for example `options=['-7', '-L 1']` (default: `[]`)
     -  `Atted` - a wrapper object to be used for ncatted. Atted objects can be included in the options list
@@ -93,33 +93,33 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
 *  File information:
 
     ```python
-    ncdump_string = nco.ncdump(input_file=ifile)
+    ncdump_string = nco.ncdump(input=ifile)
     ```
 
 *  Operators with user defined regular output files:
 
     ```python
-    nco.ncra(input_file=ifile, output=ofile)
+    nco.ncra(input=ifile, output=ofile)
     ```
 
 *  Use temporary output files:
 
     ```python
-    temp_ofile = nco.ncrcat(input_file=ifile)
+    temp_ofile = nco.ncrcat(input=ifile)
     ```
 
 *  Set global NCO options:
 
     ```python
-    nco.ncks(input_file=ifile, output=ofile, options="--netcdf4")
+    nco.ncks(input=ifile, output=ofile, options="--netcdf4")
     ```
 
 *  Return multi-dimension arrays:
 
     ```python
-    temperatures = nco.ncra(input_file=ifile, return_array=True).variables['T'][:]
-    temperatures = nco.ncra(input_file=ifile, return_cdf=True).variables['T'][:]
-    temperatures = nco.ncra(input_file=ifile, return_array='T')
+    temperatures = nco.ncra(input=ifile, returnArray=True).variables['T'][:]
+    temperatures = nco.ncra(input=ifile, returnCdf=True).variables['T'][:]
+    temperatures = nco.ncra(input=ifile, returnArray='T')
     ```
 
 * Wrapper Objects
@@ -132,7 +132,7 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
 
     ```
     ncatted -a _FillValue,three_dmn,o,d,-9.91e+33 in.nc
-    nco.ncatted(input_file="in.nc",options=[c.atted("overwrite","_FillValue","three_dmn",-9.91e+33,'d')])
+    nco.ncatted(input="in.nc",options=[c.atted("overwrite","_FillValue","three_dmn",-9.91e+33,'d')])
     ```
 
 ## Tempfile helpers
@@ -141,13 +141,13 @@ Now any NCO command (i.e. `ncks`, `ncra`, ...) can be called as a method of `nco
 absence of a specified output file, `pynco` will create a temporary file to allow the results of the task to be returned to the user.  For example:
 
 ```python
-temperatures = nco.ncra(input_file=ifile, return_array='T')
+temperatures = nco.ncra(input=ifile, returnArray='T')
 ```
 
 is equivalent to:
 
 ```
-temperatures = nco.ncra(input_file=ifile, output=tempfile.mktemp(), return_array='T')
+temperatures = nco.ncra(input=ifile, output=tempfile.mktemp(), returnArray='T')
 ```
 
 
@@ -162,7 +162,7 @@ opt = [
     c.Atted("m", "max", "temperature", 283.01, 'float64'),
     c.Atted("c", "bnds", "time", [0.5, 1.5], 'f')
 ]
-nco.ncatted(input_file="in.nc", options=opt)
+nco.ncatted(input="in.nc", options=opt)
 ```
 
 You can also use keyword arguments in the call so the above options become
@@ -174,7 +174,7 @@ opt = [
     c.Atted(mode="modify", attName="max", varName="temperature", Value=283.01, sType='float64'),
     c.Atted(mode="create", attName="bnds", varName="time", Value=[0.5, 1.5], sType='float32')
 ]
-nco.ncatted(input_file="in.nc", options=opt)
+nco.ncatted(input="in.nc", options=opt)
 ```
 
 #### `Value`
@@ -218,7 +218,7 @@ opt = [
     c.Limit(dmn_name="lev", srd=4)
 ]
 
-nco.ncks(input_file="in.nc", output="out.nc", options=opt)
+nco.ncks(input="in.nc", output="out.nc", options=opt)
 ```
 
 ##  Rename wrapper
@@ -238,7 +238,7 @@ rDict = {
     'p': 'pressure',
     't': 'temperature'
 }
-nco.ncrename(input_file="in.nc", options=[ c.Rename("variable", rDict) ])
+nco.ncrename(input="in.nc", options=[ c.Rename("variable", rDict) ])
 ```
 
 Also equivalent:
@@ -256,7 +256,7 @@ rDict = {
     'lon': 'longitude',
     'lat': 'latitude'
 }
-nco.ncrename(input_file="in.nc", options=[ c.Rename("d", rDict), c.Rename("v", rDict) ])
+nco.ncrename(input="in.nc", options=[ c.Rename("d", rDict), c.Rename("v", rDict) ])
 ```
 
 ## Support, Issues, Bugs, ...

--- a/nco/__init__.py
+++ b/nco/__init__.py
@@ -1,1 +1,1 @@
-from .nco import Nco, NCOException, which
+from .nco import Nco, NCOException

--- a/nco/custom.py
+++ b/nco/custom.py
@@ -15,91 +15,94 @@ import numpy as np
 DEBUG = 1
 
 # valid values for rename type
-RENAME_TYPES = dict({
-    'attribute': 'a',
-    'dimension': 'd',
-    'group': 'g',
-    'variable': 'v'
-})
+RENAME_TYPES = dict({"attribute": "a", "dimension": "d", "group": "g", "variable": "v"})
 
 # check mode
-VALID_MODES = dict({
-    'create': 'c',
-    'delete': 'd',
-    'modify': 'm',
-    'append': 'a',
-    'nappend': 'n',
-    'overwrite': 'o'
-})
+VALID_MODES = dict(
+    {
+        "create": "c",
+        "delete": "d",
+        "modify": "m",
+        "append": "a",
+        "nappend": "n",
+        "overwrite": "o",
+    }
+)
 
 # netCDF type names
-NET_TYPES = dict({
-    'NC_FLOAT': 'f',
-    'NC_DOUBLE': 'd',
-    'NC_INT': 'i',
-    'NC_SHORT': 's',
-    'NC_CHAR': 'c',
-    'NC_BYTE': 'b',
-    'NC_UBYTE': 'ub',
-    'NC_USHORT': 'us',
-    'NC_UINT': 'ui',
-    'NC_INT64': 'll',
-    'NC_UINT64': 'ull',
-    'NC_STRING': 'sng'
-})
+NET_TYPES = dict(
+    {
+        "NC_FLOAT": "f",
+        "NC_DOUBLE": "d",
+        "NC_INT": "i",
+        "NC_SHORT": "s",
+        "NC_CHAR": "c",
+        "NC_BYTE": "b",
+        "NC_UBYTE": "ub",
+        "NC_USHORT": "us",
+        "NC_UINT": "ui",
+        "NC_INT64": "ll",
+        "NC_UINT64": "ull",
+        "NC_STRING": "sng",
+    }
+)
 
 # numpy type names
-NP_TYPES = dict({
-    'float32': 'f',
-    'float64': 'd',
-    'int32': 'i',
-    'int16': 's',
-    'char': 'c',
-    'byte': 'b',
-    'ubyte': 'ub',
-    'int8': 'b',
-    'uint8': 'ub',
-    'uint16': 'us',
-    'uint32': 'ui',
-    'int64': 'll',
-    'uint64': 'ull',
-    'string': 'sng'
-})
+NP_TYPES = dict(
+    {
+        "float32": "f",
+        "float64": "d",
+        "int32": "i",
+        "int16": "s",
+        "char": "c",
+        "byte": "b",
+        "ubyte": "ub",
+        "int8": "b",
+        "uint8": "ub",
+        "uint16": "us",
+        "uint32": "ui",
+        "int64": "ll",
+        "uint64": "ull",
+        "string": "sng",
+    }
+)
 
-NP_TYPESNP = dict({
-    'float32': np.float32,
-    'float': np.float32,
-    'f': np.float32,
-    'float64': np.float64,
-    'double': np.float64,
-    'd': np.float64,
-    'int32': np.int32,
-    'i': np.int32,
-    'l': np.int32,
-    'int16': np.int16,
-    's': np.int16,
-    'str': str,
-    'char': str,
-    'c': str,
-    'string': str,
-    'sng': str,
-    'byte': np.byte,
-    'b': np.byte,
-    'ubyte': np.ubyte,
-    'ub': np.ubyte,
-    'int8': np.byte,
-    'uint8': np.ubyte,
-    'uint16': np.uint16,
-    'us': np.uint16,
-    'uint32': np.uint32,
-    'u': np.uint32,
-    'ui': np.uint32,
-    'ul': np.uint32,
-    'int64': np.int64,
-    'll': np.int64,
-    'uint64': np.uint64,
-    'ull': np.uint64
-})
+NP_TYPESNP = dict(
+    {
+        "float32": np.float32,
+        "float": np.float32,
+        "f": np.float32,
+        "float64": np.float64,
+        "double": np.float64,
+        "d": np.float64,
+        "int32": np.int32,
+        "i": np.int32,
+        "l": np.int32,
+        "int16": np.int16,
+        "s": np.int16,
+        "str": str,
+        "char": str,
+        "c": str,
+        "string": str,
+        "sng": str,
+        "byte": np.byte,
+        "b": np.byte,
+        "ubyte": np.ubyte,
+        "ub": np.ubyte,
+        "int8": np.byte,
+        "uint8": np.ubyte,
+        "uint16": np.uint16,
+        "us": np.uint16,
+        "uint32": np.uint32,
+        "u": np.uint32,
+        "ui": np.uint32,
+        "ul": np.uint32,
+        "int64": np.int64,
+        "ll": np.int64,
+        "uint64": np.uint64,
+        "ull": np.uint64,
+    }
+)
 
 __prog__ = os.path.splitext(os.path.basename(__file__))[0]
 
@@ -114,13 +117,20 @@ class Atted(object):
      att_typ = f,d,l/i,s,c,b,ub,us,u,ll,ull,sng
      """
 
-    def __init__(self, mode='overwrite', att_name="", var_name="", value=None,
-                 stype=None, **kwargs):
-        mode = kwargs.pop('mode', mode)
-        att_name = kwargs.pop('att_name', att_name)
-        var_name = kwargs.pop('var_name', var_name)
-        value = kwargs.pop('value', value)
-        stype = kwargs.pop('stype', stype)
+    def __init__(
+        self,
+        mode="overwrite",
+        att_name="",
+        var_name="",
+        value=None,
+        stype=None,
+        **kwargs
+    ):
+        mode = kwargs.pop("mode", mode)
+        att_name = kwargs.pop("att_name", att_name)
+        var_name = kwargs.pop("var_name", var_name)
+        value = kwargs.pop("value", value)
+        stype = kwargs.pop("stype", stype)
 
         if mode in VALID_MODES:
             mode = VALID_MODES[mode]
@@ -130,7 +140,7 @@ class Atted(object):
             raise KeyError('mode "{0}" not found'.format(mode))
 
         if not att_name:
-            raise ValueError('att_name is required')
+            raise ValueError("att_name is required")
 
         # set member defaults
         self.mode = mode
@@ -148,7 +158,7 @@ class Atted(object):
         # string the the output type should be 'sng and NOT 'c'. To do this we
         # put the single string inside a list the the prnOptions() method
         # treats it as it would a list of strings
-        if isinstance(value, str) and stype in ['string', 'sng']:
+        if isinstance(value, str) and stype in ["string", "sng"]:
             value = [value]
 
         # see if value is iterable
@@ -167,8 +177,10 @@ class Atted(object):
             try:
                 np_type = NP_TYPESNP[stype]
             except:
-                raise KeyError('specified Type "{0}" not found.\nValid '
-                               'values {1}\n'.format(stype, NP_TYPES.keys()))
+                raise KeyError(
+                    'specified Type "{0}" not found.\nValid '
+                    "values {1}\n".format(stype, NP_TYPES.keys())
+                )
         # set default types
         else:
             if input_type is int:
@@ -185,7 +197,8 @@ class Atted(object):
                 except KeyError:
                     raise KeyError(
                         'The type of value "{0}" is NOT valid\nValid '
-                        'values {1}\n'.format(input_type, NP_TYPES.keys()))
+                        "values {1}\n".format(input_type, NP_TYPES.keys())
+                    )
 
         if biterable:
             if np_type is str:
@@ -195,7 +208,7 @@ class Atted(object):
                 # get max string length
                 lenMax = len(max(sList, key=len))
                 # create array of 'fixed' length strings
-                np_value = np.array(sList, 'S{0}'.format(lenMax))
+                np_value = np.array(sList, "S{0}".format(lenMax))
             else:
                 # create array from iterable all in one go !!
                 np_value = np.fromiter(value, np_type)
@@ -207,17 +220,21 @@ class Atted(object):
             self.np_value = np_value
 
     def __str__(self):
-        return ('mode="{0}" att_name="{1}" var_name="{2} value="{3}" '
-                'type="{4}"\n'.format(self.mode, self.att_name, self.var_name,
-                                      self.np_value, self.np_type))
+        return (
+            'mode="{0}" att_name="{1}" var_name="{2} value="{3}" '
+            'type="{4}"\n'.format(
+                self.mode, self.att_name, self.var_name, self.np_value, self.np_type
+            )
+        )
 
     def prn_option(self):
 
         # modeChar=VALID_MODES[self.mode]
         # deal with delete - nb doesnt need any data
-        if self.mode == 'd':
-            return ('-a "{0}","{1}",{2},,'.
-                    format(self.att_name, self.var_name, self.mode))
+        if self.mode == "d":
+            return '-a "{0}","{1}",{2},,'.format(
+                self.att_name, self.var_name, self.mode
+            )
 
         bList = isinstance(self.np_value, (list, np.ndarray))
 
@@ -244,11 +261,9 @@ class Atted(object):
 
         strvalue = ",".join(strArray)
 
-        return '-a "{0}","{1}",{2},{3},{4}'.format(self.att_name,
-                                                   self.var_name,
-                                                   self.mode,
-                                                   type_char,
-                                                   strvalue)
+        return '-a "{0}","{1}",{2},{3},{4}'.format(
+            self.att_name, self.var_name, self.mode, type_char, strvalue
+        )
 
 
 class Limit(object):
@@ -261,14 +276,14 @@ class Limit(object):
 
     def __init__(self, dmn_name="", srt="", end="", srd="", drn="", **kwargs):
 
-        dmn_name = kwargs.pop('dmn_name', dmn_name)
-        srt = kwargs.pop('srt', srt)
-        end = kwargs.pop('end', end)
-        srd = kwargs.pop('srd', srd)
-        drn = kwargs.pop('drn', drn)
+        dmn_name = kwargs.pop("dmn_name", dmn_name)
+        srt = kwargs.pop("srt", srt)
+        end = kwargs.pop("end", end)
+        srd = kwargs.pop("srd", srd)
+        drn = kwargs.pop("drn", drn)
 
         if not dmn_name:
-            raise ValueError('dmn_name is required')
+            raise ValueError("dmn_name is required")
 
         self.dmn_name = dmn_name
         # set rest of defaults
@@ -297,8 +312,9 @@ class Limit(object):
             self.drn = np.dtype(np.int64).type(drn)
 
     def __str__(self):
-        return ("dmn_name={} srt={} end={} srd={} drn={}".
-                format(self.dmn_name, self.srt, self.end, self.srd, self.drn))
+        return "dmn_name={} srt={} end={} srd={} drn={}".format(
+            self.dmn_name, self.srt, self.end, self.srd, self.drn
+        )
 
     def prn_option(self):
         bstr = '-d "{0}",{1},{2}'.format(self.dmn_name, self.srt, self.end)

--- a/nco/nco.py
+++ b/nco/nco.py
@@ -281,7 +281,8 @@ class Nco(object):
                     file_name_prefix = nco_command + "_" + input_file.split(os.sep)[-1]
                     tmp_file = tempfile.NamedTemporaryFile(mode='w+b',
                                                            prefix=file_name_prefix,
-                                                           suffix=".tmp")
+                                                           suffix=".tmp",
+                                                           delete=False)
                     output = tmp_file.name
                     cmd.append("--output={0}".format(output))
 
@@ -298,7 +299,7 @@ class Nco(object):
             if return_array:
                 return self.read_array(output, return_array)
             elif return_ma_array:
-                return self.readMaArray(output, return_ma_array)
+                return self.read_ma_array(output, return_ma_array)
             elif self.return_cdf or return_cdf:
                 if not self.return_cdf:
                     self.load_cdf_module()
@@ -441,7 +442,7 @@ class Nco(object):
             print("Cannot find variable: {0}".format(var_name))
             raise KeyError
 
-    def readMaArray(self, infile, var_name):
+    def read_ma_array(self, infile, var_name):
         """Create a masked array based on cdf's FillValue"""
         file_obj = self.read_cdf(infile)
 

--- a/nco/nco.py
+++ b/nco/nco.py
@@ -79,12 +79,10 @@ class Nco(object):
         self.operators = operators
         self.return_cdf = returnCdf
         self.return_none_on_error = return_none_on_error
-        self.tempfile = MyTempfile()
         self.force_output = force_output
         self.cdf_module = cdf_module
         self.debug = debug
         self.outputOperatorsPattern = [
-            "ncdump",
             "-H",
             "--data",
             "--hieronymus",
@@ -333,12 +331,9 @@ class Nco(object):
                         # we assume it's an iterable.
                         if len(output) > 1:
                             raise TypeError(
-                                "Only one output allowed, \
-                                            must be string or 1 length \
-                                            iterable. Recieved output: {0} \
-                                            with a type of \
-                                            {1}".format(
-                                    output, type(output)
+                                "Only one output allowed, must be string or 1 length iterable. "
+                                "Recieved output: {out} with a type of {type}".format(
+                                    out=output, type=type(output)
                                 )
                             )
                         cmd.extend("--output={0}".format(output))
@@ -546,34 +541,6 @@ class Nco(object):
             retval = np.ma.array(data)
 
         return retval
-
-
-class MyTempfile(object):
-    """Helper module for easy temp file handling"""
-
-    __tempfiles = []
-
-    def __init__(self):
-        self.persistent_tempfile = False
-
-    def __del__(self):
-        # remove temporary files
-        for filename in self.__class__.__tempfiles:
-            if os.path.isfile(filename):
-                os.remove(filename)
-
-    def set_persistent_tempfiles(self, value):
-        self.persistent_tempfiles = value
-
-    def path(self):
-        if not self.persistent_tempfile:
-            t = tempfile.NamedTemporaryFile(
-                delete=True, prefix="nco.py_", suffix=".nco.tmp"
-            )
-            self.__class__.__tempfiles.append(t.name)
-            t.close()
-
-            return t.name
 
 
 def auto_doc(tool, nco_self):

--- a/nco/nco.py
+++ b/nco/nco.py
@@ -38,22 +38,43 @@ class NCOException(Exception):
         self.stdout = stdout
         self.stderr = stderr
         self.returncode = returncode
-        self.msg = '(returncode:{0}) {1}'.format(returncode, stderr)
+        self.msg = "(returncode:{0}) {1}".format(returncode, stderr)
 
     def __str__(self):
         return self.msg
 
 
 class Nco(object):
-    def __init__(self, returnCdf=False, return_none_on_error=False,
-                 force_output=True, cdf_module='netcdf4', debug=0, **kwargs):
+    def __init__(
+        self,
+        returnCdf=False,
+        return_none_on_error=False,
+        force_output=True,
+        cdf_module="netcdf4",
+        debug=0,
+        **kwargs
+    ):
 
-        operators = ['ncap2', 'ncatted', 'ncbo', 'nces', 'ncecat', 'ncflint', 'ncks', 'ncpdq', 'ncra', 'ncrcat', 'ncrename', 'ncwa', 'ncea']
+        operators = [
+            "ncap2",
+            "ncatted",
+            "ncbo",
+            "nces",
+            "ncecat",
+            "ncflint",
+            "ncks",
+            "ncpdq",
+            "ncra",
+            "ncrcat",
+            "ncrename",
+            "ncwa",
+            "ncea",
+        ]
 
-        if 'NCOpath' in os.environ:
-            self.nco_path = os.environ['NCOpath']
+        if "NCOpath" in os.environ:
+            self.nco_path = os.environ["NCOpath"]
         else:
-            self.nco_path = os.path.split(distutils.spawn.find_executable('ncks'))[0]
+            self.nco_path = os.path.split(distutils.spawn.find_executable("ncks"))[0]
 
         self.operators = operators
         self.return_cdf = returnCdf
@@ -62,17 +83,34 @@ class Nco(object):
         self.force_output = force_output
         self.cdf_module = cdf_module
         self.debug = debug
-        self.outputOperatorsPattern = ['ncdump', '-H', '--data',
-                                       '--hieronymus', '-M', '--Mtd',
-                                       '--Metadata', '-m', '--mtd',
-                                       '--metadata', '-P', '--prn', '--print',
-                                       '-r', '--revision', '--vrs',
-                                       '--version', '--u', '--units']
-        self.OverwriteOperatorsPattern = ['-O', '--ovr', '--overwrite']
-        self.AppendOperatorsPattern = ['-A', '--apn', '--append']
-        self.DontForcePattern = (self.outputOperatorsPattern +
-                                 self.OverwriteOperatorsPattern +
-                                 self.AppendOperatorsPattern)
+        self.outputOperatorsPattern = [
+            "ncdump",
+            "-H",
+            "--data",
+            "--hieronymus",
+            "-M",
+            "--Mtd",
+            "--Metadata",
+            "-m",
+            "--mtd",
+            "--metadata",
+            "-P",
+            "--prn",
+            "--print",
+            "-r",
+            "--revision",
+            "--vrs",
+            "--version",
+            "--u",
+            "--units",
+        ]
+        self.OverwriteOperatorsPattern = ["-O", "--ovr", "--overwrite"]
+        self.AppendOperatorsPattern = ["-A", "--apn", "--append"]
+        self.DontForcePattern = (
+            self.outputOperatorsPattern
+            + self.OverwriteOperatorsPattern
+            + self.AppendOperatorsPattern
+        )
         # I/O from call
         self.returncode = 0
         self.stdout = ""
@@ -99,40 +137,50 @@ class Nco(object):
                 inline_cmd.extend(inputs)
 
         if self.debug:
-            print('# DEBUG ==================================================')
+            print("# DEBUG ==================================================")
             if environment:
                 for key, val in list(environment.items()):
                     print("# DEBUG: ENV: {0} = {1}".format(key, val))
-            print('# DEBUG: CALL>> {0}'.format(' '.join(inline_cmd)))
-            print('# DEBUG ==================================================')
+            print("# DEBUG: CALL>> {0}".format(" ".join(inline_cmd)))
+            print("# DEBUG ==================================================")
 
         # if we're using the shell then we need to pass a single string as the command rather than in iterable
         if use_shell:
-            inline_cmd = ' '.join(inline_cmd)
+            inline_cmd = " ".join(inline_cmd)
 
         try:
-            proc = subprocess.Popen(inline_cmd,
-                                    shell=use_shell,
-                                    stderr=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    env=environment)
+            proc = subprocess.Popen(
+                inline_cmd,
+                shell=use_shell,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                env=environment,
+            )
         except OSError:
             # Argument list may have been too long, so don't use a shell
-            proc = subprocess.Popen(inline_cmd,
-                                    stderr=subprocess.PIPE,
-                                    stdout=subprocess.PIPE,
-                                    env=environment)
+            proc = subprocess.Popen(
+                inline_cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                env=environment,
+            )
         retvals = proc.communicate()
-        return {"stdout": retvals[0],
-                "stderr": retvals[1],
-                "returncode": proc.returncode}
+        return {
+            "stdout": retvals[0],
+            "stderr": retvals[1],
+            "returncode": proc.returncode,
+        }
 
     def has_error(self, method_name, inputs, cmd, retvals):
         if self.debug:
-            print("# DEBUG: RETURNCODE: {return_code}".format(return_code=retvals["returncode"]))
+            print(
+                "# DEBUG: RETURNCODE: {return_code}".format(
+                    return_code=retvals["returncode"]
+                )
+            )
         if retvals["returncode"] != 0:
             print("Error in calling operator {method} with:".format(method=method_name))
-            print(">>> {command} <<<".format(command=' '.join(cmd)))
+            print(">>> {command} <<<".format(command=" ".join(cmd)))
             print("Inputs: {0!s}".format(inputs))
             print(retvals["stderr"])
             return True
@@ -157,7 +205,7 @@ class Nco(object):
             :param kwargs:
             :return:
             """
-            options = kwargs.pop('options', [])
+            options = kwargs.pop("options", [])
             force = kwargs.pop("force", self.force_output)
             output = kwargs.pop("output", None)
             environment = kwargs.pop("env", None)
@@ -185,12 +233,16 @@ class Nco(object):
             if debug:
                 if type(debug) == bool:
                     # assume debug level is 3
-                    cmd.append('--nco_dbg_lvl=3')
+                    cmd.append("--nco_dbg_lvl=3")
                 elif type(debug) == int:
-                    cmd.append('--nco_dbg_lvl={0}'.format(debug))
+                    cmd.append("--nco_dbg_lvl={0}".format(debug))
                 else:
-                    raise TypeError('Unknown type for debug: \
-                                    {0}'.format(type(debug)))
+                    raise TypeError(
+                        "Unknown type for debug: \
+                                    {0}".format(
+                            type(debug)
+                        )
+                    )
 
             if output and force and os.path.isfile(output):
                 # make sure overwrite is set
@@ -208,19 +260,25 @@ class Nco(object):
                         cmd.append("--{0}".format(key))
                         if cmd[-1] in self.DontForcePattern:
                             force = False
-                    elif isinstance(val, six.string_types) or \
-                            isinstance(val, int) or \
-                            isinstance(val, float):
+                    elif (
+                        isinstance(val, six.string_types)
+                        or isinstance(val, int)
+                        or isinstance(val, float)
+                    ):
                         cmd.append("--{option}={value}".format(option=key, value=val))
                     else:
                         # we assume it's either a list, a tuple or any iterable
-                        cmd.append("--{option}={values}".format(option=key, values=",".join(val)))
+                        cmd.append(
+                            "--{option}={values}".format(
+                                option=key, values=",".join(val)
+                            )
+                        )
 
             # 2c. Global options come in
             if self.options:
                 for key, val in list(self.options.items()):
                     if val and type(val) == bool:
-                        cmd.append("--"+key)
+                        cmd.append("--" + key)
                     elif isinstance(val, six.string_types):
                         cmd.append("--{0}={1}".format(key, val))
                     else:
@@ -229,7 +287,7 @@ class Nco(object):
 
             # 3.  Add in overwrite if necessary
             if force:
-                cmd.append('--overwrite')
+                cmd.append("--overwrite")
 
             # Check if operator appends
             operator_appends = False
@@ -239,11 +297,15 @@ class Nco(object):
 
             # If operator appends and NCO version >= 4.3.7, remove -H -M -m
             # and their ancillaries from outputOperatorsPattern
-            if operator_appends and nco_command == 'ncks':
+            if operator_appends and nco_command == "ncks":
                 nco_version = self.version()
-                if LooseVersion(nco_version) >= LooseVersion('4.3.7'):
+                if LooseVersion(nco_version) >= LooseVersion("4.3.7"):
                     self.outputOperatorsPattern = [
-                        '-r', '--revision', '--vrs', '--version']
+                        "-r",
+                        "--revision",
+                        "--vrs",
+                        "--version",
+                    ]
 
             # Check if operator prints out
             for piece in cmd:
@@ -270,26 +332,30 @@ class Nco(object):
                     else:
                         # we assume it's an iterable.
                         if len(output) > 1:
-                            raise TypeError('Only one output allowed, \
+                            raise TypeError(
+                                "Only one output allowed, \
                                             must be string or 1 length \
                                             iterable. Recieved output: {0} \
                                             with a type of \
-                                            {1}'.format(output,
-                                                        type(output)))
+                                            {1}".format(
+                                    output, type(output)
+                                )
+                            )
                         cmd.extend("--output={0}".format(output))
 
                 else:
 
                     # create a temporary file, use this as the output
                     file_name_prefix = nco_command + "_" + input.split(os.sep)[-1]
-                    tmp_file = tempfile.NamedTemporaryFile(mode='w+b',
-                                                           prefix=file_name_prefix,
-                                                           suffix=".tmp",
-                                                           delete=False)
+                    tmp_file = tempfile.NamedTemporaryFile(
+                        mode="w+b", prefix=file_name_prefix, suffix=".tmp", delete=False
+                    )
                     output = tmp_file.name
                     cmd.append("--output={0}".format(output))
 
-                retvals = self.call(cmd, inputs=input, environment=environment, use_shell=use_shell)
+                retvals = self.call(
+                    cmd, inputs=input, environment=environment, use_shell=use_shell
+                )
                 self.returncode = retvals["returncode"]
                 self.stdout = retvals["stdout"]
                 self.stderr = retvals["stderr"]
@@ -310,8 +376,7 @@ class Nco(object):
             else:
                 return output
 
-        if (nco_command in self.__dict__) or \
-                (nco_command in self.operators):
+        if (nco_command in self.__dict__) or (nco_command in self.operators):
             if self.debug:
                 print("Found method: {0}".format(nco_command))
             # cache the method for later
@@ -327,20 +392,28 @@ class Nco(object):
         if self.cdf_module == "netcdf4":
             try:
                 import netCDF4 as cdf
+
                 self.cdf = cdf
             except Exception:
-                raise ImportError("Could not load python-netcdf4 - try to "
-                                  "setting 'cdf_module='scipy'")
+                raise ImportError(
+                    "Could not load python-netcdf4 - try to "
+                    "setting 'cdf_module='scipy'"
+                )
         elif self.cdf_module == "scipy":
             try:
                 import scipy.io.netcdf as cdf
+
                 self.cdf = cdf
             except Exception:
-                raise ImportError("Could not load scipy.io.netcdf - try to "
-                                  "setting 'cdf_module='netcdf4'")
+                raise ImportError(
+                    "Could not load scipy.io.netcdf - try to "
+                    "setting 'cdf_module='netcdf4'"
+                )
         else:
-            raise ValueError("Unknown value provided for cdf_module.  Valid "
-                             "values are 'scipy' and 'netcdf4'")
+            raise ValueError(
+                "Unknown value provided for cdf_module.  Valid "
+                "values are 'scipy' and 'netcdf4'"
+            )
 
     def set_return_array(self, value=True):
         self.returnCdf = value
@@ -361,10 +434,10 @@ class Nco(object):
 
     def check_nco(self):
         if self.has_nco():
-            call = [os.path.join(self.nco_path, 'ncra'), '--version']
-            proc = subprocess.Popen(' '.join(call),
-                                    stderr=subprocess.PIPE,
-                                    stdout=subprocess.PIPE)
+            call = [os.path.join(self.nco_path, "ncra"), "--version"]
+            proc = subprocess.Popen(
+                " ".join(call), stderr=subprocess.PIPE, stdout=subprocess.PIPE
+            )
             retvals = proc.communicate()
             print(retvals)
 
@@ -379,25 +452,24 @@ class Nco(object):
     # ------------------------------------------------------------------
     @property
     def module_version(self):
-        return '0.0.0'
+        return "0.0.0"
 
     def version(self):
         # return NCO's version
-        proc = subprocess.Popen([os.path.join(self.nco_path, 'ncra'),
-                                 '--version'],
-                                stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE)
+        proc = subprocess.Popen(
+            [os.path.join(self.nco_path, "ncra"), "--version"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
         ret = proc.communicate()
         ncra_help = ret[1]
         if isinstance(ncra_help, bytes):
-            ncra_help = ncra_help.decode('utf-8')
-        match = re.search('NCO netCDF Operators version (\d.*) ',
-                          ncra_help)
+            ncra_help = ncra_help.decode("utf-8")
+        match = re.search("NCO netCDF Operators version (\d.*) ", ncra_help)
         # some versions write version information in quotation marks
         if not match:
-            match = re.search('NCO netCDF Operators version "(\d.*)" ',
-                              ncra_help)
-        return match.group(1).split(' ')[0]
+            match = re.search('NCO netCDF Operators version "(\d.*)" ', ncra_help)
+        return match.group(1).split(" ")[0]
 
     def read_cdf(self, infile):
         """Return a cdf handle created by the available cdf library.
@@ -407,12 +479,16 @@ class Nco(object):
 
         if self.cdf_module == "scipy":
             # making it compatible to older scipy versions
-            file_obj = self.cdf.netcdf_file(infile, mode='r')
+            file_obj = self.cdf.netcdf_file(infile, mode="r")
         elif self.cdf_module == "netcdf4":
             file_obj = self.cdf.Dataset(infile)
         else:
-            raise ImportError("Could not import data \
-                              from file {0}".format(infile))
+            raise ImportError(
+                "Could not import data \
+                              from file {0}".format(
+                    infile
+                )
+            )
         return file_obj
 
     def open_cdf(self, infile):
@@ -424,13 +500,17 @@ class Nco(object):
         if self.cdf_module == "scipy":
             # making it compatible to older scipy versions
             print("Use scipy")
-            file_obj = self.cdf.netcdf_file(infile, mode='r+')
+            file_obj = self.cdf.netcdf_file(infile, mode="r+")
         elif self.cdf_module == "netcdf4":
             print("Use netcdf4")
-            file_obj = self.cdf.Dataset(infile, 'r+')
+            file_obj = self.cdf.Dataset(infile, "r+")
         else:
-            raise ImportError("Could not import data \
-                              from file: {0}".format(infile))
+            raise ImportError(
+                "Could not import data \
+                              from file: {0}".format(
+                    infile
+                )
+            )
 
         return file_obj
 
@@ -457,7 +537,7 @@ class Nco(object):
         except Exception:
             raise ImportError("numpy is required to return masked arrays.")
 
-        if hasattr(file_obj.variables[var_name], '_FillValue'):
+        if hasattr(file_obj.variables[var_name], "_FillValue"):
             # return masked array
             fill_val = file_obj.variables[var_name]._FillValue
             retval = np.ma.masked_where(data == fill_val, data)
@@ -470,6 +550,7 @@ class Nco(object):
 
 class MyTempfile(object):
     """Helper module for easy temp file handling"""
+
     __tempfiles = []
 
     def __init__(self):
@@ -486,8 +567,9 @@ class MyTempfile(object):
 
     def path(self):
         if not self.persistent_tempfile:
-            t = tempfile.NamedTemporaryFile(delete=True, prefix='nco.py_',
-                                            suffix='.nco.tmp')
+            t = tempfile.NamedTemporaryFile(
+                delete=True, prefix="nco.py_", suffix=".nco.tmp"
+            )
             self.__class__.__tempfiles.append(t.name)
             t.close()
 
@@ -502,9 +584,10 @@ def auto_doc(tool, nco_self):
     :param nco_self:
     :return:
     """
+
     def desc(func):
 
-        func.__doc__ = nco_self.call([tool, '--help']).get('stdout')
+        func.__doc__ = nco_self.call([tool, "--help"]).get("stdout")
         return func
 
     return desc

--- a/nco/nco.py
+++ b/nco/nco.py
@@ -28,7 +28,7 @@ import tempfile
 from distutils.version import LooseVersion
 import six
 
-from nco.custom import Atted
+from nco import custom
 
 
 class NCOException(Exception):
@@ -171,7 +171,7 @@ class Nco(object):
                 for option in options:
                     if isinstance(option, six.string_types):
                         cmd.extend(shlex.split(option))
-                    elif isinstance(option, Atted):
+                    elif isinstance(option, custom.Atted):
                         cmd.extend(option.prn_option().split())
                     else:
                         # assume it's an iterable

--- a/setup.py
+++ b/setup.py
@@ -22,31 +22,26 @@ License:
 
 from setuptools import setup
 
-version = '0.0.4'
+version = "0.0.4"
 
-setup(name='nco',
-      version=version,
-      author="Joe Hamman",
-      author_email="jhamman@ucar.edu",
-      license="GPLv2",
-      description="""python bindings to NCO""",
-      packages=['nco'],
-      py_modules=["nco.nco", "nco.custom"],
-      url="https://github.com/nco/pynco",
-      download_url="https://raw2.github.com/nco/pynco/tarball/{0}".format(
-          version),
-      keywords=['netcdf', 'climate'],
-      classifiers=["Development Status :: 4 - Beta",
-                   "Topic :: Utilities",
-                   "Operating System :: POSIX",
-                   "Programming Language :: Python",
-                   ], install_requires=['six'],
-      tests_require=[
-          "dateutil",
-          "h5py",
-          "netcdf4",
-          "numpy",
-          "pytest",
-          "scipy"
-      ],
-      )
+setup(
+    name="nco",
+    version=version,
+    author="Joe Hamman",
+    author_email="jhamman@ucar.edu",
+    license="GPLv2",
+    description="""python bindings to NCO""",
+    packages=["nco"],
+    py_modules=["nco.nco", "nco.custom"],
+    url="https://github.com/nco/pynco",
+    download_url="https://raw2.github.com/nco/pynco/tarball/{0}".format(version),
+    keywords=["netcdf", "climate"],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Topic :: Utilities",
+        "Operating System :: POSIX",
+        "Programming Language :: Python",
+    ],
+    install_requires=["six"],
+    tests_require=["dateutil", "h5py", "netcdf4", "numpy", "pytest", "scipy"],
+)

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,13 @@ setup(name='nco',
                    "Topic :: Utilities",
                    "Operating System :: POSIX",
                    "Programming Language :: Python",
-                   ], install_requires=['six']
+                   ], install_requires=['six'],
+      tests_require=[
+          "dateutil",
+          "h5py",
+          "netcdf4",
+          "numpy",
+          "pytest",
+          "scipy"
+      ],
       )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ import numpy as np
 import pytest
 
 # constants
-_UNITS_STD_TIME = 'days since 1990-01-01'
-_CALENDAR_NO_LEAP = 'noleap'
-_DATESTR_FORMAT_MONTHLY = 'Foo.bar.ha.%Y-%m.nc'
+_UNITS_STD_TIME = "days since 1990-01-01"
+_CALENDAR_NO_LEAP = "noleap"
+_DATESTR_FORMAT_MONTHLY = "Foo.bar.ha.%Y-%m.nc"
 
 
 @pytest.fixture(scope="module")
@@ -50,10 +50,11 @@ def random_masked_field(mask4tests):
 def hdf_file(random_field, tempsrcdir):
     try:
         import h5py
-        filename = os.path.join(tempsrcdir, 'testhdf.hdf5')
-        f = h5py.File(filename, 'w')
+
+        filename = os.path.join(tempsrcdir, "testhdf.hdf5")
+        f = h5py.File(filename, "w")
         shape = random_field.shape
-        dset = f.create_dataset("random_field", shape, dtype='f')
+        dset = f.create_dataset("random_field", shape, dtype="f")
         dset[:, :] = random_field
         f.close()
         return filename
@@ -65,14 +66,14 @@ def hdf_file(random_field, tempsrcdir):
 def foo_nc(random_field):
     """ a simple netCDF file with a random field"""
     tempdir = tempsrcdir()
-    filename = os.path.join(tempdir, 'foo.nc')
-    dataset = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
+    filename = os.path.join(tempdir, "foo.nc")
+    dataset = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
     shape = random_field.shape
-    dataset.createDimension('dim0', shape[0])
-    dataset.createDimension('dim1', shape[1])
-    dataset.createDimension('time', None)
-    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = dataset.createVariable('time', 'f8', ('time',))
+    dataset.createDimension("dim0", shape[0])
+    dataset.createDimension("dim1", shape[1])
+    dataset.createDimension("time", None)
+    var = dataset.createVariable("random", "f8", ("time", "dim0", "dim1"))
+    time = dataset.createVariable("time", "f8", ("time",))
     time.units = _UNITS_STD_TIME
     var[0, :, :] = random_field
     time[:] = 1.0
@@ -84,16 +85,16 @@ def foo_nc(random_field):
 def bar_nc(random_field):
     """ a simple netCDF file with a random field * 2"""
     tempdir = tempsrcdir()
-    filename = os.path.join(tempdir, 'bar.nc')
-    dataset = netCDF4.Dataset(filename, 'w')
+    filename = os.path.join(tempdir, "bar.nc")
+    dataset = netCDF4.Dataset(filename, "w")
     shape = random_field.shape
-    dataset.createDimension('dim0', shape[0])
-    dataset.createDimension('dim1', shape[1])
-    dataset.createDimension('time', None)
-    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = dataset.createVariable('time', 'f8', ('time',))
+    dataset.createDimension("dim0", shape[0])
+    dataset.createDimension("dim1", shape[1])
+    dataset.createDimension("time", None)
+    var = dataset.createVariable("random", "f8", ("time", "dim0", "dim1"))
+    time = dataset.createVariable("time", "f8", ("time",))
     time.units = _UNITS_STD_TIME
-    var[0, :, :] = random_field*2.0
+    var[0, :, :] = random_field * 2.0
     time[:] = 2.0
     dataset.close()
     return filename
@@ -103,17 +104,17 @@ def bar_nc(random_field):
 def bar_mask_nc(random_masked_field):
     """ a simple netCDF file with a random field * 2"""
     tempdir = tempsrcdir()
-    filename = os.path.join(tempdir, 'bar.nc')
-    dataset = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
+    filename = os.path.join(tempdir, "bar.nc")
+    dataset = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
 
     shape = random_masked_field.shape
-    dataset.createDimension('dim0', shape[1])
-    dataset.createDimension('dim1', shape[2])
-    dataset.createDimension('time', 1)
-    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = dataset.createVariable('time', 'f8', ('time',))
+    dataset.createDimension("dim0", shape[1])
+    dataset.createDimension("dim1", shape[2])
+    dataset.createDimension("time", 1)
+    var = dataset.createVariable("random", "f8", ("time", "dim0", "dim1"))
+    time = dataset.createVariable("time", "f8", ("time",))
     time.units = _UNITS_STD_TIME
-    var[:, :, :] = random_masked_field*2.0
+    var[:, :, :] = random_masked_field * 2.0
     time[:] = 2.0
     dataset.close()
     return filename
@@ -127,18 +128,17 @@ def monthly_filelist(random_field, monthlydatetimelist, tempsrcdir):
     for date in monthlydatetimelist:
         filename = date.strftime(_DATESTR_FORMAT_MONTHLY)
         filename = os.path.join(tempdir, filename)
-        dataset = netCDF4.Dataset(filename, 'w')
+        dataset = netCDF4.Dataset(filename, "w")
         shape = random_field.shape
-        dataset.createDimension('dim0', shape[0])
-        dataset.createDimension('dim1', shape[1])
-        dataset.createDimension('time', 1)
-        var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-        time = dataset.createVariable('time', 'f8', ('time',))
+        dataset.createDimension("dim0", shape[0])
+        dataset.createDimension("dim1", shape[1])
+        dataset.createDimension("time", 1)
+        var = dataset.createVariable("random", "f8", ("time", "dim0", "dim1"))
+        time = dataset.createVariable("time", "f8", ("time",))
         time.units = _UNITS_STD_TIME
         time.calendar = _CALENDAR_NO_LEAP
         var[:, :, :] = random_field
-        time[:] = netCDF4.date2num(date, _UNITS_STD_TIME,
-                                   calendar=_CALENDAR_NO_LEAP)
+        time[:] = netCDF4.date2num(date, _UNITS_STD_TIME, calendar=_CALENDAR_NO_LEAP)
         dataset.close()
 
         file_list.append(filename)
@@ -153,18 +153,17 @@ def testfiles8589(random_field, tempsrcdir):
         date = datetime.datetime(year, 1, 1)
         filename = date.strftime("%y.nc")
         filename = os.path.join(tempsrcdir, filename)
-        dataset = netCDF4.Dataset(filename, 'w')
+        dataset = netCDF4.Dataset(filename, "w")
         shape = random_field.shape
-        dataset.createDimension('dim0', shape[0])
-        dataset.createDimension('dim1', shape[1])
-        dataset.createDimension('time')
-        var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-        time = dataset.createVariable('time', 'f8', ('time',))
+        dataset.createDimension("dim0", shape[0])
+        dataset.createDimension("dim1", shape[1])
+        dataset.createDimension("time")
+        var = dataset.createVariable("random", "f8", ("time", "dim0", "dim1"))
+        time = dataset.createVariable("time", "f8", ("time",))
         time.units = _UNITS_STD_TIME
         time.calendar = _CALENDAR_NO_LEAP
         var[0, :, :] = random_field
-        time[:] = netCDF4.date2num(date, _UNITS_STD_TIME,
-                                   calendar=_CALENDAR_NO_LEAP)
+        time[:] = netCDF4.date2num(date, _UNITS_STD_TIME, calendar=_CALENDAR_NO_LEAP)
         dataset.close()
 
         filelist.append(filename)
@@ -174,17 +173,19 @@ def testfiles8589(random_field, tempsrcdir):
 @pytest.fixture(scope="module")
 def testfile85(random_field, tempsrcdir):
     """Create a bunch of sample monthly netcdf files with real times"""
-    dates = [datetime.datetime(1985, 1, 1) + datetime.timedelta(days=d) for
-             d in range(0, 365)]
+    dates = [
+        datetime.datetime(1985, 1, 1) + datetime.timedelta(days=d)
+        for d in range(0, 365)
+    ]
     tempdir = tempsrcdir()
     filename = os.path.join(tempdir, "85.nc")
-    dataset = netCDF4.Dataset(filename, 'w')
+    dataset = netCDF4.Dataset(filename, "w")
     shape = random_field.shape
-    dataset.createDimension('dim0', shape[0])
-    dataset.createDimension('dim1', shape[1])
-    dataset.createDimension('time', len(dates))
-    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = dataset.createVariable('time', 'f8', ('time',))
+    dataset.createDimension("dim0", shape[0])
+    dataset.createDimension("dim1", shape[1])
+    dataset.createDimension("time", len(dates))
+    var = dataset.createVariable("random", "f8", ("time", "dim0", "dim1"))
+    time = dataset.createVariable("time", "f8", ("time",))
     time.units = _UNITS_STD_TIME
     time.calendar = _CALENDAR_NO_LEAP
     var[:, :, :] = random_field
@@ -198,22 +199,22 @@ def testfileglobal(tempsrcdir):
     """Create a bunch of sample monthly netcdf files with real times"""
     dates = [datetime.datetime.now()]
     filename = os.path.join(tempsrcdir, "global.nc")
-    dataset = netCDF4.Dataset(filename, 'w')
+    dataset = netCDF4.Dataset(filename, "w")
     random_field = np.random.rand(1, 180, 360)  # 1degree resolution
     shape = random_field.shape
-    dataset.createDimension('lat', shape[1])
-    dataset.createDimension('lon', shape[2])
-    dataset.createDimension('time', len(dates))
-    var = dataset.createVariable('random', 'f8', ('time', 'lat', 'lon',))
-    lon = dataset.createVariable('lon', 'f8', ('lon',))
-    lat = dataset.createVariable('lat', 'f8', ('lat',))
-    time = dataset.createVariable('time', 'f8', ('time',))
+    dataset.createDimension("lat", shape[1])
+    dataset.createDimension("lon", shape[2])
+    dataset.createDimension("time", len(dates))
+    var = dataset.createVariable("random", "f8", ("time", "lat", "lon"))
+    lon = dataset.createVariable("lon", "f8", ("lon",))
+    lat = dataset.createVariable("lat", "f8", ("lat",))
+    time = dataset.createVariable("time", "f8", ("time",))
     time.units = _UNITS_STD_TIME
     time.calendar = _CALENDAR_NO_LEAP
     var[:, :, :] = random_field
     time[:] = netCDF4.date2num(dates, _UNITS_STD_TIME, calendar=_CALENDAR_NO_LEAP)
-    lat[:] = np.linspace(-90., 90., shape[1])
-    lon[:] = np.linspace(-180., 180, shape[2])
+    lat[:] = np.linspace(-90.0, 90.0, shape[1])
+    lon[:] = np.linspace(-180.0, 180, shape[2])
     dataset.close()
     return filename
 
@@ -221,29 +222,31 @@ def testfileglobal(tempsrcdir):
 @pytest.fixture(scope="module")
 def monthlydatetimelist():
     """list of monthly datetimes"""
-    return [datetime.datetime(2000, 1, 1)
-            + relativedelta.relativedelta(months=i) for i in range(12)]
+    return [
+        datetime.datetime(2000, 1, 1) + relativedelta.relativedelta(months=i)
+        for i in range(12)
+    ]
 
 
 @pytest.fixture(scope="module")
 def foo3c(tempsrcdir):
-    filename = os.path.join(tempsrcdir, 'foo_3c.nc')
-    dataset = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
+    filename = os.path.join(tempsrcdir, "foo_3c.nc")
+    dataset = netCDF4.Dataset(filename, "w", format="NETCDF3_CLASSIC")
     dataset.close()
     return filename
 
 
 @pytest.fixture(scope="module")
 def foo364(tempsrcdir):
-    filename = os.path.join(tempsrcdir, 'foo_364.nc')
-    f = netCDF4.Dataset(filename, 'w', format='NETCDF3_64BIT')
+    filename = os.path.join(tempsrcdir, "foo_364.nc")
+    f = netCDF4.Dataset(filename, "w", format="NETCDF3_64BIT")
     f.close()
     return filename
 
 
 @pytest.fixture(scope="module")
 def foo4c(tempsrcdir):
-    filename = os.path.join(tempsrcdir, 'foo_4c.nc')
-    f = netCDF4.Dataset(filename, 'w', format='NETCDF4_CLASSIC')
+    filename = os.path.join(tempsrcdir, "foo_4c.nc")
+    f = netCDF4.Dataset(filename, "w", format="NETCDF4_CLASSIC")
     f.close()
     return filename

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,16 @@
-
-# content of conftest.py
-import os
-import pytest
-import tempfile
-import numpy as np
-import netCDF4
 import datetime
-from dateutil import relativedelta
+import os
+import tempfile
 
-stdtimeunits = 'days since 1990-01-01'
-noleapcalendar = 'noleap'
-monthlydatestrformat = 'Foo.bar.ha.%Y-%m.nc'
+from dateutil import relativedelta
+import netCDF4
+import numpy as np
+import pytest
+
+# constants
+_UNITS_STD_TIME = 'days since 1990-01-01'
+_CALENDAR_NO_LEAP = 'noleap'
+_DATESTR_FORMAT_MONTHLY = 'Foo.bar.ha.%Y-%m.nc'
 
 
 @pytest.fixture(scope="module")
@@ -66,17 +66,17 @@ def foo_nc(random_field):
     """ a simple netCDF file with a random field"""
     tempdir = tempsrcdir()
     filename = os.path.join(tempdir, 'foo.nc')
-    f = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
+    dataset = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
     shape = random_field.shape
-    f.createDimension('dim0', shape[0])
-    f.createDimension('dim1', shape[1])
-    time = f.createDimension('time', None)
-    var = f.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = f.createVariable('time', 'f8', ('time'))
-    time.units = stdtimeunits
+    dataset.createDimension('dim0', shape[0])
+    dataset.createDimension('dim1', shape[1])
+    dataset.createDimension('time', None)
+    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
+    time = dataset.createVariable('time', 'f8', ('time',))
+    time.units = _UNITS_STD_TIME
     var[0, :, :] = random_field
     time[:] = 1.0
-    f.close()
+    dataset.close()
     return filename
 
 
@@ -85,17 +85,17 @@ def bar_nc(random_field):
     """ a simple netCDF file with a random field * 2"""
     tempdir = tempsrcdir()
     filename = os.path.join(tempdir, 'bar.nc')
-    f = netCDF4.Dataset(filename, 'w')
+    dataset = netCDF4.Dataset(filename, 'w')
     shape = random_field.shape
-    f.createDimension('dim0', shape[0])
-    f.createDimension('dim1', shape[1])
-    time = f.createDimension('time', None)
-    var = f.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = f.createVariable('time', 'f8', ('time'))
-    time.units = stdtimeunits
+    dataset.createDimension('dim0', shape[0])
+    dataset.createDimension('dim1', shape[1])
+    dataset.createDimension('time', None)
+    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
+    time = dataset.createVariable('time', 'f8', ('time',))
+    time.units = _UNITS_STD_TIME
     var[0, :, :] = random_field*2.0
     time[:] = 2.0
-    f.close()
+    dataset.close()
     return filename
 
 
@@ -104,45 +104,45 @@ def bar_mask_nc(random_masked_field):
     """ a simple netCDF file with a random field * 2"""
     tempdir = tempsrcdir()
     filename = os.path.join(tempdir, 'bar.nc')
-    f = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
+    dataset = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
 
     shape = random_masked_field.shape
-    f.createDimension('dim0', shape[1])
-    f.createDimension('dim1', shape[2])
-    time = f.createDimension('time', 1)
-    var = f.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = f.createVariable('time', 'f8', ('time'))
-    time.units = stdtimeunits
+    dataset.createDimension('dim0', shape[1])
+    dataset.createDimension('dim1', shape[2])
+    dataset.createDimension('time', 1)
+    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
+    time = dataset.createVariable('time', 'f8', ('time',))
+    time.units = _UNITS_STD_TIME
     var[:, :, :] = random_masked_field*2.0
     time[:] = 2.0
-    f.close()
+    dataset.close()
     return filename
 
 
 @pytest.fixture(scope="module")
 def monthly_filelist(random_field, monthlydatetimelist, tempsrcdir):
     """Create a bunch of sample monthly netcdf files with real times"""
-    filelist = []
+    file_list = []
     tempdir = tempsrcdir()
     for date in monthlydatetimelist:
-        filename = date.strftime(monthlydatestrformat)
+        filename = date.strftime(_DATESTR_FORMAT_MONTHLY)
         filename = os.path.join(tempdir, filename)
-        f = netCDF4.Dataset(filename, 'w')
+        dataset = netCDF4.Dataset(filename, 'w')
         shape = random_field.shape
-        f.createDimension('dim0', shape[0])
-        f.createDimension('dim1', shape[1])
-        time = f.createDimension('time', 1)
-        var = f.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-        time = f.createVariable('time', 'f8', ('time'))
-        time.units = stdtimeunits
-        time.calendar = noleapcalendar
+        dataset.createDimension('dim0', shape[0])
+        dataset.createDimension('dim1', shape[1])
+        dataset.createDimension('time', 1)
+        var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
+        time = dataset.createVariable('time', 'f8', ('time',))
+        time.units = _UNITS_STD_TIME
+        time.calendar = _CALENDAR_NO_LEAP
         var[:, :, :] = random_field
-        time[:] = netCDF4.date2num(date, stdtimeunits,
-                                   calendar=noleapcalendar)
-        f.close()
+        time[:] = netCDF4.date2num(date, _UNITS_STD_TIME,
+                                   calendar=_CALENDAR_NO_LEAP)
+        dataset.close()
 
-        filelist.append(filename)
-    return filelist
+        file_list.append(filename)
+    return file_list
 
 
 @pytest.fixture(scope="module")
@@ -153,19 +153,19 @@ def testfiles8589(random_field, tempsrcdir):
         date = datetime.datetime(year, 1, 1)
         filename = date.strftime("%y.nc")
         filename = os.path.join(tempsrcdir, filename)
-        f = netCDF4.Dataset(filename, 'w')
+        dataset = netCDF4.Dataset(filename, 'w')
         shape = random_field.shape
-        f.createDimension('dim0', shape[0])
-        f.createDimension('dim1', shape[1])
-        f.createDimension('time')
-        var = f.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-        time = f.createVariable('time', 'f8', ('time'))
-        time.units = stdtimeunits
-        time.calendar = noleapcalendar
+        dataset.createDimension('dim0', shape[0])
+        dataset.createDimension('dim1', shape[1])
+        dataset.createDimension('time')
+        var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
+        time = dataset.createVariable('time', 'f8', ('time',))
+        time.units = _UNITS_STD_TIME
+        time.calendar = _CALENDAR_NO_LEAP
         var[0, :, :] = random_field
-        time[:] = netCDF4.date2num(date, stdtimeunits,
-                                   calendar=noleapcalendar)
-        f.close()
+        time[:] = netCDF4.date2num(date, _UNITS_STD_TIME,
+                                   calendar=_CALENDAR_NO_LEAP)
+        dataset.close()
 
         filelist.append(filename)
     return filelist
@@ -178,18 +178,18 @@ def testfile85(random_field, tempsrcdir):
              d in range(0, 365)]
     tempdir = tempsrcdir()
     filename = os.path.join(tempdir, "85.nc")
-    f = netCDF4.Dataset(filename, 'w')
+    dataset = netCDF4.Dataset(filename, 'w')
     shape = random_field.shape
-    f.createDimension('dim0', shape[0])
-    f.createDimension('dim1', shape[1])
-    time = f.createDimension('time', len(dates))
-    var = f.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
-    time = f.createVariable('time', 'f8', ('time'))
-    time.units = stdtimeunits
-    time.calendar = noleapcalendar
+    dataset.createDimension('dim0', shape[0])
+    dataset.createDimension('dim1', shape[1])
+    dataset.createDimension('time', len(dates))
+    var = dataset.createVariable('random', 'f8', ('time', 'dim0', 'dim1',))
+    time = dataset.createVariable('time', 'f8', ('time',))
+    time.units = _UNITS_STD_TIME
+    time.calendar = _CALENDAR_NO_LEAP
     var[:, :, :] = random_field
-    time[:] = netCDF4.date2num(dates, stdtimeunits, calendar=noleapcalendar)
-    f.close()
+    time[:] = netCDF4.date2num(dates, _UNITS_STD_TIME, calendar=_CALENDAR_NO_LEAP)
+    dataset.close()
     return filename
 
 
@@ -197,25 +197,24 @@ def testfile85(random_field, tempsrcdir):
 def testfileglobal(tempsrcdir):
     """Create a bunch of sample monthly netcdf files with real times"""
     dates = [datetime.datetime.now()]
-    # tempdir = tempsrcdir()
     filename = os.path.join(tempsrcdir, "global.nc")
-    f = netCDF4.Dataset(filename, 'w')
+    dataset = netCDF4.Dataset(filename, 'w')
     random_field = np.random.rand(1, 180, 360)  # 1degree resolution
     shape = random_field.shape
-    f.createDimension('lat', shape[1])
-    f.createDimension('lon', shape[2])
-    time = f.createDimension('time', len(dates))
-    var = f.createVariable('random', 'f8', ('time', 'lat', 'lon',))
-    lon = f.createVariable('lon', 'f8', ('lon',))
-    lat = f.createVariable('lat', 'f8', ('lat',))
-    time = f.createVariable('time', 'f8', ('time'))
-    time.units = stdtimeunits
-    time.calendar = noleapcalendar
+    dataset.createDimension('lat', shape[1])
+    dataset.createDimension('lon', shape[2])
+    dataset.createDimension('time', len(dates))
+    var = dataset.createVariable('random', 'f8', ('time', 'lat', 'lon',))
+    lon = dataset.createVariable('lon', 'f8', ('lon',))
+    lat = dataset.createVariable('lat', 'f8', ('lat',))
+    time = dataset.createVariable('time', 'f8', ('time',))
+    time.units = _UNITS_STD_TIME
+    time.calendar = _CALENDAR_NO_LEAP
     var[:, :, :] = random_field
-    time[:] = netCDF4.date2num(dates, stdtimeunits, calendar=noleapcalendar)
+    time[:] = netCDF4.date2num(dates, _UNITS_STD_TIME, calendar=_CALENDAR_NO_LEAP)
     lat[:] = np.linspace(-90., 90., shape[1])
     lon[:] = np.linspace(-180., 180, shape[2])
-    f.close()
+    dataset.close()
     return filename
 
 
@@ -229,8 +228,8 @@ def monthlydatetimelist():
 @pytest.fixture(scope="module")
 def foo3c(tempsrcdir):
     filename = os.path.join(tempsrcdir, 'foo_3c.nc')
-    f = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
-    f.close()
+    dataset = netCDF4.Dataset(filename, 'w', format='NETCDF3_CLASSIC')
+    dataset.close()
     return filename
 
 

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -60,7 +60,7 @@ def testOps():
 
 def test_mod_version():
     nco = Nco()
-    assert '0.0.0' == nco.module_version()
+    assert '0.0.0' == nco.module_version
 
 
 def test_getOperators():

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -33,7 +33,7 @@ from nco.custom import Atted, Limit, LimitSingle, Rename
 
 
 ops = ['ncap2', 'ncatted', 'ncbo', 'nces', 'ncecat', 'ncflint', 'ncks',
-       'ncpdq', 'ncra', 'ncrcat', 'ncrename', 'ncwa', 'ncdump']
+       'ncpdq', 'ncra', 'ncrcat', 'ncrename', 'ncwa']
 
 
 def test_nco_present():
@@ -77,7 +77,7 @@ def test_list_all_operators():
 def test_use_list_inputs(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncrcat(input_file=infiles, output='out.nc')
+    nco.ncrcat(input=infiles, output='out.nc')
 
 
 @pytest.mark.usefixtures("foo_nc")
@@ -87,51 +87,51 @@ def test_use_list_options(foo_nc):
     options.extend(['-a', 'units,time,o,c,"days since 1999-01-01"'])
     options.extend(['-a', 'long_name,time,o,c,time'])
     options.extend(['-a', 'calendar,time,o,c,noleap'])
-    nco.ncatted(input_file=foo_nc, output='out.nc', options=options)
+    nco.ncatted(input=foo_nc, output='out.nc', options=options)
 
 
 @pytest.mark.usefixtures("foo_nc", "bar_nc")
 def test_ncra_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncra(input_file=infiles, output='out.nc')
+    nco.ncra(input=infiles, output='out.nc')
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_ncra_single_file(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
-    nco.ncra(input_file=infile, output='out.nc')
+    nco.ncra(input=infile, output='out.nc')
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_ncks_extract(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
-    nco.ncks(input_file=infile, output='out.nc', variable='random')
+    nco.ncks(input=infile, output='out.nc', variable='random')
 
 
 @pytest.mark.usefixtures("foo_nc", "bar_nc")
 def test_ncea_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncea(input_file=infiles, output='out.nc')
+    nco.ncea(input=infiles, output='out.nc')
 
 
 def test_error_exception():
     nco = Nco()
     assert hasattr(nco, 'nonExistingMethod') is False
     with pytest.raises(NCOException):
-        nco.ncks(input_file="", output="")
+        nco.ncks(input="", output="")
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_return_array(foo_nc):
     nco = Nco(cdf_module='netcdf4')
-    random1 = nco.ncea(input_file=foo_nc, output="tmp.nc", return_cdf=True,
+    random1 = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
                        options=['-O']).variables['random'][:]
     assert isinstance(random1, np.ndarray)
-    random2 = nco.ncea(input_file=foo_nc, output="tmp.nc", return_array='random',
+    random2 = nco.ncea(input=foo_nc, output="tmp.nc", returnArray='random',
                        options=['-O'])
     assert isinstance(random2, np.ndarray)
     np.testing.assert_equal(random1, random2)
@@ -140,15 +140,15 @@ def test_return_array(foo_nc):
 @pytest.mark.usefixtures("bar_mask_nc", "random_masked_field")
 def test_return_ma_array(bar_mask_nc, random_masked_field):
     nco = Nco()
-    field = nco.ncea(input_file=bar_mask_nc, output="tmp.nc",
-                     return_ma_array='random', options=['-O'])
+    field = nco.ncea(input=bar_mask_nc, output="tmp.nc",
+                     returnMaArray='random', options=['-O'])
     assert type(field) == np.ma.core.MaskedArray
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_return_cdf(foo_nc):
     nco = Nco(cdf_module='scipy')
-    test_cdf = nco.ncea(input_file=foo_nc, output="tmp.nc", return_cdf=True,
+    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
                         options=['-O'])
     assert type(test_cdf) == scipy.io.netcdf.netcdf_file
     expected_vars = ['time', 'random']
@@ -156,7 +156,7 @@ def test_return_cdf(foo_nc):
         assert var in list(test_cdf.variables.keys())
 
     nco = Nco(cdf_module='netcdf4')
-    test_cdf = nco.ncea(input_file=foo_nc, output="tmp.nc", return_cdf=True,
+    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
                         options=['-O'])
     assert type(test_cdf) == netCDF4.Dataset
     for var in expected_vars:
@@ -254,7 +254,7 @@ def test_init_options():
     assert nco.debug
     nco = Nco(force_output=False)
     assert nco.force_output is False
-    nco = Nco(return_cdf=True,
+    nco = Nco(returnCdf=True,
               return_none_on_error=True)
     assert nco.return_cdf
     assert nco.return_none_on_error
@@ -263,5 +263,5 @@ def test_init_options():
 @pytest.mark.usefixtures("bar_nc")
 def test_operator_prints_out(bar_nc):
     nco = Nco()
-    dump = nco.ncdump(input_file=bar_nc, options=['-h'])
+    dump = nco.ncks(input=bar_nc, options=['--help'])
     print(dump)

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -32,12 +32,24 @@ from nco import NCOException, Nco
 from nco.custom import Atted, Limit, LimitSingle, Rename
 
 
-ops = ['ncap2', 'ncatted', 'ncbo', 'nces', 'ncecat', 'ncflint', 'ncks',
-       'ncpdq', 'ncra', 'ncrcat', 'ncrename', 'ncwa']
+ops = [
+    "ncap2",
+    "ncatted",
+    "ncbo",
+    "nces",
+    "ncecat",
+    "ncflint",
+    "ncks",
+    "ncpdq",
+    "ncra",
+    "ncrcat",
+    "ncrename",
+    "ncwa",
+]
 
 
 def test_nco_present():
-    ncopath = distutils.spawn.find_executable('ncks')
+    ncopath = distutils.spawn.find_executable("ncks")
     # ncopath = which('ncks')
     assert os.path.isfile(ncopath)
 
@@ -58,7 +70,7 @@ def test_ops():
 
 def test_mod_version():
     nco = Nco()
-    assert '0.0.0' == nco.module_version
+    assert "0.0.0" == nco.module_version
 
 
 def test_get_operators():
@@ -77,62 +89,64 @@ def test_list_all_operators():
 def test_use_list_inputs(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncrcat(input=infiles, output='out.nc')
+    nco.ncrcat(input=infiles, output="out.nc")
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_use_list_options(foo_nc):
     nco = Nco(debug=True)
     options = []
-    options.extend(['-a', 'units,time,o,c,"days since 1999-01-01"'])
-    options.extend(['-a', 'long_name,time,o,c,time'])
-    options.extend(['-a', 'calendar,time,o,c,noleap'])
-    nco.ncatted(input=foo_nc, output='out.nc', options=options)
+    options.extend(["-a", 'units,time,o,c,"days since 1999-01-01"'])
+    options.extend(["-a", "long_name,time,o,c,time"])
+    options.extend(["-a", "calendar,time,o,c,noleap"])
+    nco.ncatted(input=foo_nc, output="out.nc", options=options)
 
 
 @pytest.mark.usefixtures("foo_nc", "bar_nc")
 def test_ncra_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncra(input=infiles, output='out.nc')
+    nco.ncra(input=infiles, output="out.nc")
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_ncra_single_file(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
-    nco.ncra(input=infile, output='out.nc')
+    nco.ncra(input=infile, output="out.nc")
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_ncks_extract(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
-    nco.ncks(input=infile, output='out.nc', variable='random')
+    nco.ncks(input=infile, output="out.nc", variable="random")
 
 
 @pytest.mark.usefixtures("foo_nc", "bar_nc")
 def test_ncea_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncea(input=infiles, output='out.nc')
+    nco.ncea(input=infiles, output="out.nc")
 
 
 def test_error_exception():
     nco = Nco()
-    assert hasattr(nco, 'nonExistingMethod') is False
+    assert hasattr(nco, "nonExistingMethod") is False
     with pytest.raises(NCOException):
         nco.ncks(input="", output="")
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_return_array(foo_nc):
-    nco = Nco(cdf_module='netcdf4')
-    random1 = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
-                       options=['-O']).variables['random'][:]
+    nco = Nco(cdf_module="netcdf4")
+    random1 = nco.ncea(
+        input=foo_nc, output="tmp.nc", returnCdf=True, options=["-O"]
+    ).variables["random"][:]
     assert isinstance(random1, np.ndarray)
-    random2 = nco.ncea(input=foo_nc, output="tmp.nc", returnArray='random',
-                       options=['-O'])
+    random2 = nco.ncea(
+        input=foo_nc, output="tmp.nc", returnArray="random", options=["-O"]
+    )
     assert isinstance(random2, np.ndarray)
     np.testing.assert_equal(random1, random2)
 
@@ -140,24 +154,23 @@ def test_return_array(foo_nc):
 @pytest.mark.usefixtures("bar_mask_nc", "random_masked_field")
 def test_return_ma_array(bar_mask_nc, random_masked_field):
     nco = Nco()
-    field = nco.ncea(input=bar_mask_nc, output="tmp.nc",
-                     returnMaArray='random', options=['-O'])
+    field = nco.ncea(
+        input=bar_mask_nc, output="tmp.nc", returnMaArray="random", options=["-O"]
+    )
     assert type(field) == np.ma.core.MaskedArray
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_return_cdf(foo_nc):
-    nco = Nco(cdf_module='scipy')
-    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
-                        options=['-O'])
+    nco = Nco(cdf_module="scipy")
+    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True, options=["-O"])
     assert type(test_cdf) == scipy.io.netcdf.netcdf_file
-    expected_vars = ['time', 'random']
+    expected_vars = ["time", "random"]
     for var in expected_vars:
         assert var in list(test_cdf.variables.keys())
 
-    nco = Nco(cdf_module='netcdf4')
-    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
-                        options=['-O'])
+    nco = Nco(cdf_module="netcdf4")
+    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True, options=["-O"])
     assert type(test_cdf) == netCDF4.Dataset
     for var in expected_vars:
         assert var in list(test_cdf.variables.keys())
@@ -166,37 +179,87 @@ def test_return_cdf(foo_nc):
 @pytest.fixture(scope="module")
 def test_atted():
     atted_list = [
-        Atted(mode="overwrite", att_name="units", var_name="temperature",
-              value="Kelvin"),
-        Atted(mode="overwrite", att_name="min", var_name="temperature",
-              value=-127, stype='byte'),
-        Atted(mode="overwrite", att_name="max", var_name="temperature",
-              value=127, stype='int16'),
-        Atted(mode="modify", att_name="min-max", var_name="pressure",
-              value=[100, 10000], stype='int32'),
-        Atted(mode="create", att_name="array", var_name="time_bands",
-              value=range(1, 10, 2), stype='d'),
-        Atted(mode="append", att_name="mean", var_name="time_bands",
-              value=3.14159826253),  # default to double
-        Atted(mode="append", att_name="mean_float", var_name="time_bands",
-              value=3.14159826253, stype='float'),
+        Atted(
+            mode="overwrite", att_name="units", var_name="temperature", value="Kelvin"
+        ),
+        Atted(
+            mode="overwrite",
+            att_name="min",
+            var_name="temperature",
+            value=-127,
+            stype="byte",
+        ),
+        Atted(
+            mode="overwrite",
+            att_name="max",
+            var_name="temperature",
+            value=127,
+            stype="int16",
+        ),
+        Atted(
+            mode="modify",
+            att_name="min-max",
+            var_name="pressure",
+            value=[100, 10000],
+            stype="int32",
+        ),
+        Atted(
+            mode="create",
+            att_name="array",
+            var_name="time_bands",
+            value=range(1, 10, 2),
+            stype="d",
+        ),
+        Atted(
+            mode="append", att_name="mean", var_name="time_bands", value=3.14159826253
+        ),  # default to double
+        Atted(
+            mode="append",
+            att_name="mean_float",
+            var_name="time_bands",
+            value=3.14159826253,
+            stype="float",
+        ),
         # d convert type to float
-        Atted(mode="append", att_name="mean_sng", var_name="time_bands",
-              value=3.14159826253, stype='char'),
-        Atted(mode="nappend", att_name="units", var_name="height",
-              value="height in mm", stype='string'),
-        Atted(mode="create", att_name="long_name", var_name="height",
-              value="height in feet"),
-        Atted(mode="nappend", att_name="units", var_name="blob",
-              value=[1000000., 2.], stype='d')
+        Atted(
+            mode="append",
+            att_name="mean_sng",
+            var_name="time_bands",
+            value=3.14159826253,
+            stype="char",
+        ),
+        Atted(
+            mode="nappend",
+            att_name="units",
+            var_name="height",
+            value="height in mm",
+            stype="string",
+        ),
+        Atted(
+            mode="create",
+            att_name="long_name",
+            var_name="height",
+            value="height in feet",
+        ),
+        Atted(
+            mode="nappend",
+            att_name="units",
+            var_name="blob",
+            value=[1000000.0, 2.0],
+            stype="d",
+        ),
     ]
 
     # regular function args
     atted_list += [
-        Atted("append", "long_name", "temperature",
-              ("mean", "sea", "level", "temperature")),
+        Atted(
+            "append",
+            "long_name",
+            "temperature",
+            ("mean", "sea", "level", "temperature"),
+        ),
         Atted("delete", "short_name", "temp"),
-        Atted("delete", "long_name", "relative_humidity")
+        Atted("delete", "long_name", "relative_humidity"),
     ]
 
     ar = ("mean", "sea", "level", "temperature", 3.1459, 2.0)
@@ -208,44 +271,45 @@ def test_atted():
     atted_list += [
         Atted("append", "long_name", "temperature", ar),
         Atted(mode="delete", att_name=".*"),
-        Atted(mode="append", att_name="array", var_name="time", value=val,
-              stype='ll'),
-        Atted(mode="append", att_name="bool", var_name="time", value=val2,
-              stype='b'),
-        Atted("nappend", "long", "random", 2 ** 33, stype='ull')
+        Atted(mode="append", att_name="array", var_name="time", value=val, stype="ll"),
+        Atted(mode="append", att_name="bool", var_name="time", value=val2, stype="b"),
+        Atted("nappend", "long", "random", 2 ** 33, stype="ull"),
     ]
 
     for atted in atted_list:
         print(atted.prn_option())
 
-    limit_list = [Limit("lat", 0.0, 88.1),
-                  Limit("time", 0, 10, 3),
-                  Limit("time", 1.0, 2e9, 3),
-                  Limit(dmn_name="three", srt=10, end=30, srd=4, drn=2),
-                  Limit(dmn_name="three", srd=4),
-                  Limit(dmn_name="three", drn=3),
-                  LimitSingle("three", 20.0)]
+    limit_list = [
+        Limit("lat", 0.0, 88.1),
+        Limit("time", 0, 10, 3),
+        Limit("time", 1.0, 2e9, 3),
+        Limit(dmn_name="three", srt=10, end=30, srd=4, drn=2),
+        Limit(dmn_name="three", srd=4),
+        Limit(dmn_name="three", drn=3),
+        LimitSingle("three", 20.0),
+    ]
 
     for limit in limit_list:
         print(limit.prn_option())
 
-    renames = dict({'lon': 'longitude', 'lat': 'latitude', 'lev': 'level',
-                    'dog': 'cat'})
+    renames = dict(
+        {"lon": "longitude", "lat": "latitude", "lev": "level", "dog": "cat"}
+    )
     rename = Rename("g", renames)
     print(rename.prn_option())
 
 
 def test_cdf_mod_scipy():
-    nco = Nco(cdf_module='scipy')
+    nco = Nco(cdf_module="scipy")
     nco.set_return_array()
-    print(('nco.cdf_module: {0}'.format(nco.cdf_module)))
+    print(("nco.cdf_module: {0}".format(nco.cdf_module)))
     assert nco.cdf_module == "scipy"
 
 
 def test_cdf_mod_netcdf4():
-    nco = Nco(cdf_module='netcdf4')
+    nco = Nco(cdf_module="netcdf4")
     nco.set_return_array()
-    print(('nco.cdf_module: {0}'.format(nco.cdf_module)))
+    print(("nco.cdf_module: {0}".format(nco.cdf_module)))
     assert nco.cdf_module == "netcdf4"
 
 
@@ -254,8 +318,7 @@ def test_init_options():
     assert nco.debug
     nco = Nco(force_output=False)
     assert nco.force_output is False
-    nco = Nco(returnCdf=True,
-              return_none_on_error=True)
+    nco = Nco(returnCdf=True, return_none_on_error=True)
     assert nco.return_cdf
     assert nco.return_none_on_error
 
@@ -263,5 +326,5 @@ def test_init_options():
 @pytest.mark.usefixtures("bar_nc")
 def test_operator_prints_out(bar_nc):
     nco = Nco()
-    dump = nco.ncks(input=bar_nc, options=['--help'])
+    dump = nco.ncks(input=bar_nc, options=["--help"])
     print(dump)

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -20,6 +20,7 @@ License:
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
+import distutils.spawn
 import os
 
 import numpy as np
@@ -27,7 +28,7 @@ import netCDF4
 import scipy.io.netcdf
 import pytest
 
-from nco import NCOException, Nco, which
+from nco import NCOException, Nco
 from nco.custom import Atted, Limit, LimitSingle, Rename
 
 
@@ -36,7 +37,8 @@ ops = ['ncap2', 'ncatted', 'ncbo', 'nces', 'ncecat', 'ncflint', 'ncks',
 
 
 def test_nco_present():
-    ncopath = which('ncks')
+    ncopath = distutils.spawn.find_executable('ncks')
+    # ncopath = which('ncks')
     assert os.path.isfile(ncopath)
 
 

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -75,7 +75,7 @@ def test_list_all_operators():
 def test_use_list_inputs(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncrcat(input=infiles, output='out.nc')
+    nco.ncrcat(input_file=infiles, output='out.nc')
 
 
 @pytest.mark.usefixtures("foo_nc")
@@ -85,51 +85,51 @@ def test_use_list_options(foo_nc):
     options.extend(['-a', 'units,time,o,c,"days since 1999-01-01"'])
     options.extend(['-a', 'long_name,time,o,c,time'])
     options.extend(['-a', 'calendar,time,o,c,noleap'])
-    nco.ncatted(input=foo_nc, output='out.nc', options=options)
+    nco.ncatted(input_file=foo_nc, output='out.nc', options=options)
 
 
 @pytest.mark.usefixtures("foo_nc", "bar_nc")
 def test_ncra_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncra(input=infiles, output='out.nc')
+    nco.ncra(input_file=infiles, output='out.nc')
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_ncra_single_file(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
-    nco.ncra(input=infile, output='out.nc')
+    nco.ncra(input_file=infile, output='out.nc')
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_ncks_extract(foo_nc):
     nco = Nco(debug=True)
     infile = foo_nc
-    nco.ncks(input=infile, output='out.nc', variable='random')
+    nco.ncks(input_file=infile, output='out.nc', variable='random')
 
 
 @pytest.mark.usefixtures("foo_nc", "bar_nc")
 def test_ncea_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
-    nco.ncea(input=infiles, output='out.nc')
+    nco.ncea(input_file=infiles, output='out.nc')
 
 
 def test_error_exception():
     nco = Nco()
     assert hasattr(nco, 'nonExistingMethod') is False
     with pytest.raises(NCOException):
-        nco.ncks(input="", output="")
+        nco.ncks(input_file="", output="")
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_return_array(foo_nc):
-    nco = Nco(cdfMod='netcdf4')
-    random1 = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
+    nco = Nco(cdf_module='netcdf4')
+    random1 = nco.ncea(input_file=foo_nc, output="tmp.nc", return_cdf=True,
                        options=['-O']).variables['random'][:]
     assert isinstance(random1, np.ndarray)
-    random2 = nco.ncea(input=foo_nc, output="tmp.nc", returnArray='random',
+    random2 = nco.ncea(input_file=foo_nc, output="tmp.nc", return_array='random',
                        options=['-O'])
     assert isinstance(random2, np.ndarray)
     np.testing.assert_equal(random1, random2)
@@ -138,23 +138,23 @@ def test_return_array(foo_nc):
 @pytest.mark.usefixtures("bar_mask_nc", "random_masked_field")
 def test_return_ma_array(bar_mask_nc, random_masked_field):
     nco = Nco()
-    field = nco.ncea(input=bar_mask_nc, output="tmp.nc",
-                     returnMaArray='random', options=['-O'])
+    field = nco.ncea(input_file=bar_mask_nc, output="tmp.nc",
+                     return_ma_array='random', options=['-O'])
     assert type(field) == np.ma.core.MaskedArray
 
 
 @pytest.mark.usefixtures("foo_nc")
 def test_return_cdf(foo_nc):
-    nco = Nco(cdfMod='scipy')
-    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
+    nco = Nco(cdf_module='scipy')
+    test_cdf = nco.ncea(input_file=foo_nc, output="tmp.nc", return_cdf=True,
                         options=['-O'])
     assert type(test_cdf) == scipy.io.netcdf.netcdf_file
     expected_vars = ['time', 'random']
     for var in expected_vars:
         assert var in list(test_cdf.variables.keys())
 
-    nco = Nco(cdfMod='netcdf4')
-    test_cdf = nco.ncea(input=foo_nc, output="tmp.nc", returnCdf=True,
+    nco = Nco(cdf_module='netcdf4')
+    test_cdf = nco.ncea(input_file=foo_nc, output="tmp.nc", return_cdf=True,
                         options=['-O'])
     assert type(test_cdf) == netCDF4.Dataset
     for var in expected_vars:
@@ -234,32 +234,32 @@ def test_atted():
 
 
 def test_cdf_mod_scipy():
-    nco = Nco(cdfMod='scipy')
-    nco.setReturnArray()
-    print(('nco.cdfMod: {0}'.format(nco.cdfMod)))
-    assert nco.cdfMod == "scipy"
+    nco = Nco(cdf_module='scipy')
+    nco.set_return_array()
+    print(('nco.cdf_module: {0}'.format(nco.cdf_module)))
+    assert nco.cdf_module == "scipy"
 
 
 def test_cdf_mod_netcdf4():
-    nco = Nco(cdfMod='netcdf4')
-    nco.setReturnArray()
-    print(('nco.cdfMod: {0}'.format(nco.cdfMod)))
-    assert nco.cdfMod == "netcdf4"
+    nco = Nco(cdf_module='netcdf4')
+    nco.set_return_array()
+    print(('nco.cdf_module: {0}'.format(nco.cdf_module)))
+    assert nco.cdf_module == "netcdf4"
 
 
 def test_init_options():
     nco = Nco(debug=True)
     assert nco.debug
-    nco = Nco(forceOutput=False)
-    assert nco.forceOutput is False
-    nco = Nco(returnCdf=True,
-              returnNoneOnError=True)
-    assert nco.returnCdf
-    assert nco.returnNoneOnError
+    nco = Nco(force_output=False)
+    assert nco.force_output is False
+    nco = Nco(return_cdf=True,
+              return_none_on_error=True)
+    assert nco.return_cdf
+    assert nco.return_none_on_error
 
 
 @pytest.mark.usefixtures("bar_nc")
 def test_operator_prints_out(bar_nc):
     nco = Nco()
-    dump = nco.ncdump(input=bar_nc, options=['-h'])
+    dump = nco.ncdump(input_file=bar_nc, options=['-h'])
     print(dump)

--- a/tests/test_nco_examples.py
+++ b/tests/test_nco_examples.py
@@ -35,10 +35,10 @@ def test_ncks_hdf2nc(hdf_file):
     ncks --hdf4 fl.hdf fl.nc # Convert HDF4->netCDF4 (NCO 4.3.7-4.3.9)
     """
     if hdf_file is None:
-        pytest.skip('Skipped because h5py is not installed')
+        pytest.skip("Skipped because h5py is not installed")
     nco = Nco(debug=True)
-    nco.ncks(input=hdf_file, output='foo.nc')
-    nco.ncks(input=hdf_file, output='foo.nc', hdf4=True)
+    nco.ncks(input=hdf_file, output="foo.nc")
+    nco.ncks(input=hdf_file, output="foo.nc", hdf4=True)
 
 
 def test_ncks_hdf2nc3(hdf_file):
@@ -54,12 +54,12 @@ def test_ncks_hdf2nc3(hdf_file):
     ncks --hdf4 -7 fl.hdf fl.nc # HDF4->netCDF4 classic (netCDF 4.3.0-)
     """
     if hdf_file is None:
-        pytest.skip('Skipped because h5py is not installed')
+        pytest.skip("Skipped because h5py is not installed")
     nco = Nco(debug=True)
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-3'])
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-7 -L 1'])
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-3'], hdf4=True)
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-7'], hdf4=True)
+    nco.ncks(input=hdf_file, output="foo.nc", options=["-3"])
+    nco.ncks(input=hdf_file, output="foo.nc", options=["-7 -L 1"])
+    nco.ncks(input=hdf_file, output="foo.nc", options=["-3"], hdf4=True)
+    nco.ncks(input=hdf_file, output="foo.nc", options=["-7"], hdf4=True)
 
 
 def test_temp_output_files(foo_nc):
@@ -73,9 +73,9 @@ def test_temp_output_files(foo_nc):
     ncks --open_ram --no_tmp_fl in.nc in.nc # Read into RAM, write to disk
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo_nc, output='bar.nc')
-    nco.ncks(input=foo_nc, output='bar.nc', wrt_tmp_fl=True)
-    nco.ncks(input=foo_nc, output='bar.nc', no_tmp_fl=True)
+    nco.ncks(input=foo_nc, output="bar.nc")
+    nco.ncks(input=foo_nc, output="bar.nc", wrt_tmp_fl=True)
+    nco.ncks(input=foo_nc, output="bar.nc", no_tmp_fl=True)
     nco.ncks(input=foo_nc, output=foo_nc, no_tmp_fl=True, create_ram=True)
     nco.ncks(input=foo_nc, output=foo_nc, no_tmp_fl=True, open_ram=True)
 
@@ -88,10 +88,11 @@ def test_ncks_append_variables(foo_nc, bar_nc):
     ncks -A fl_1.nc fl_2.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo_nc, output=bar_nc, options=['-A'])
+    nco.ncks(input=foo_nc, output=bar_nc, options=["-A"])
     nco.ncks(input=foo_nc, output=bar_nc, append=True)
     nco.ncks(input=foo_nc, output=bar_nc, apn=True)
     nco.ncks(input=foo_nc, output=bar_nc)
+
 
 # def test_add_record_dimension():
 #     """
@@ -120,9 +121,9 @@ def test_command_line_options(foo_nc):
     ncks --dbg_lvl 3 in.nc # Long option, alternate form
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo_nc, options=['-O -D 3'])
-    nco.ncks(input=foo_nc, options=['-O --dbg_lvl=3'])
-    nco.ncks(input=foo_nc, options=['-O --dbg_lvl 3'])
+    nco.ncks(input=foo_nc, options=["-O -D 3"])
+    nco.ncks(input=foo_nc, options=["-O --dbg_lvl=3"])
+    nco.ncks(input=foo_nc, options=["-O --dbg_lvl 3"])
     # nco.ncks(input=foo_nc, dbg_lvl=3)
 
 
@@ -136,16 +137,16 @@ def test_specifying_input_files(testfiles8589):
     ncra -n 5,2,1 85.nc 8589.nc
     """
     nco = Nco(debug=True)
-    nco.ncra(input=testfiles8589, output='8589.nc')
-    nco.ncra(input=testfiles8589, output='8589.nc', nintap='5,2,1')
+    nco.ncra(input=testfiles8589, output="8589.nc")
+    nco.ncra(input=testfiles8589, output="8589.nc", nintap="5,2,1")
 
     srcdir = os.path.dirname(testfiles8589[0])
     basenames = [os.path.basename(x) for x in testfiles8589]
-    nco.ncra(input=basenames, output='8589.nc', path=srcdir)
+    nco.ncra(input=basenames, output="8589.nc", path=srcdir)
 
     # unable to use brackets, perhaps because we're no longer using shell=True when calling subprocess()?
-    regpath = os.path.join(srcdir, '8[56789].nc')
-    nco.ncra(input=regpath, output='8589.nc', use_shell=True)
+    regpath = os.path.join(srcdir, "8[56789].nc")
+    nco.ncra(input=regpath, output="8589.nc", use_shell=True)
 
 
 def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):
@@ -161,14 +162,14 @@ def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):
     ncks -D 2 -M foo_4.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo3c, options=['-M'])
-    nco.ncks(input=foo364, options=['-M'])
-    nco.ncks(input=foo4c, options=['-M'])
-    nco.ncks(input=foo4c, options=['-D 2 -M'])
+    nco.ncks(input=foo3c, options=["-M"])
+    nco.ncks(input=foo364, options=["-M"])
+    nco.ncks(input=foo4c, options=["-M"])
+    nco.ncks(input=foo4c, options=["-D 2 -M"])
 
     if hdf_file is not None:
         assert os.path.isfile(hdf_file)
-        nco.ncks(input=hdf_file, options=['-D 2 -M'])
+        nco.ncks(input=hdf_file, options=["-D 2 -M"])
     # nco.ncks(input='http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc',
     #          options=['-D 2', '-M']) # does not work from command line either
 
@@ -191,18 +192,18 @@ def test_file_conversion(foo3c, foo4c):
     ncks --7 in.nc foo_4c.nc # netCDF4 classic
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo4c, output='foo_3c.nc', fl_fmt='classic')
-    nco.ncks(input=foo4c, output='foo_364.nc', fl_fmt='64bit')
-    nco.ncks(input=foo3c, output='foo_4c.nc', fl_fmt='netcdf4_classic')
-    nco.ncks(input=foo3c, output='foo_4.nc', fl_fmt='netcdf4')
-    nco.ncks(input=foo4c, output='foo_3c.nc', options=['-3'])
-    nco.ncks(input=foo4c, output='foo_3c.nc', options=['--3'])
-    nco.ncks(input=foo3c, output='foo_364c.nc', options=['-6'])
-    nco.ncks(input=foo3c, output='foo_364c.nc', options=['--64bit_offset'])
-    nco.ncks(input=foo3c, output='foo_4.nc', options=['-4'])
-    nco.ncks(input=foo3c, output='foo_4.nc', options=['--4'])
-    nco.ncks(input=foo3c, output='foo_4c.nc', options=['-7'])
-    nco.ncks(input=foo3c, output='foo_4c.nc', options=['--7'])
+    nco.ncks(input=foo4c, output="foo_3c.nc", fl_fmt="classic")
+    nco.ncks(input=foo4c, output="foo_364.nc", fl_fmt="64bit")
+    nco.ncks(input=foo3c, output="foo_4c.nc", fl_fmt="netcdf4_classic")
+    nco.ncks(input=foo3c, output="foo_4.nc", fl_fmt="netcdf4")
+    nco.ncks(input=foo4c, output="foo_3c.nc", options=["-3"])
+    nco.ncks(input=foo4c, output="foo_3c.nc", options=["--3"])
+    nco.ncks(input=foo3c, output="foo_364c.nc", options=["-6"])
+    nco.ncks(input=foo3c, output="foo_364c.nc", options=["--64bit_offset"])
+    nco.ncks(input=foo3c, output="foo_4.nc", options=["-4"])
+    nco.ncks(input=foo3c, output="foo_4.nc", options=["--4"])
+    nco.ncks(input=foo3c, output="foo_4c.nc", options=["-7"])
+    nco.ncks(input=foo3c, output="foo_4c.nc", options=["--7"])
 
 
 def test_hyperslabs(testfileglobal):
@@ -227,17 +228,14 @@ def test_hyperslabs(testfileglobal):
     ncks -F -d lon,-3, in.nc out.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
-             dimension='lon,1,2')
-    nco.ncks(input=testfileglobal, output='out.nc',
-             dimension='lon,1,2')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
-             dimension='lon,1.0,2.0')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
-             dimension='lon,0.0,90.0,2')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
-             dimension='lon,1,-2')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
-             dimension='lon,-3,-1')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
-             dimension='lon,-3')
+    nco.ncks(input=testfileglobal, output="out.nc", fortran=True, dimension="lon,1,2")
+    nco.ncks(input=testfileglobal, output="out.nc", dimension="lon,1,2")
+    nco.ncks(
+        input=testfileglobal, output="out.nc", fortran=True, dimension="lon,1.0,2.0"
+    )
+    nco.ncks(
+        input=testfileglobal, output="out.nc", fortran=True, dimension="lon,0.0,90.0,2"
+    )
+    nco.ncks(input=testfileglobal, output="out.nc", fortran=True, dimension="lon,1,-2")
+    nco.ncks(input=testfileglobal, output="out.nc", fortran=True, dimension="lon,-3,-1")
+    nco.ncks(input=testfileglobal, output="out.nc", fortran=True, dimension="lon,-3")

--- a/tests/test_nco_examples.py
+++ b/tests/test_nco_examples.py
@@ -37,8 +37,8 @@ def test_ncks_hdf2nc(hdf_file):
     if hdf_file is None:
         pytest.skip('Skipped because h5py is not installed')
     nco = Nco(debug=True)
-    nco.ncks(input_file=hdf_file, output='foo.nc')
-    nco.ncks(input_file=hdf_file, output='foo.nc', hdf4=True)
+    nco.ncks(input=hdf_file, output='foo.nc')
+    nco.ncks(input=hdf_file, output='foo.nc', hdf4=True)
 
 
 def test_ncks_hdf2nc3(hdf_file):
@@ -56,10 +56,10 @@ def test_ncks_hdf2nc3(hdf_file):
     if hdf_file is None:
         pytest.skip('Skipped because h5py is not installed')
     nco = Nco(debug=True)
-    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-3'])
-    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-7 -L 1'])
-    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-3'], hdf4=True)
-    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-7'], hdf4=True)
+    nco.ncks(input=hdf_file, output='foo.nc', options=['-3'])
+    nco.ncks(input=hdf_file, output='foo.nc', options=['-7 -L 1'])
+    nco.ncks(input=hdf_file, output='foo.nc', options=['-3'], hdf4=True)
+    nco.ncks(input=hdf_file, output='foo.nc', options=['-7'], hdf4=True)
 
 
 def test_temp_output_files(foo_nc):
@@ -73,11 +73,11 @@ def test_temp_output_files(foo_nc):
     ncks --open_ram --no_tmp_fl in.nc in.nc # Read into RAM, write to disk
     """
     nco = Nco(debug=True)
-    nco.ncks(input_file=foo_nc, output='bar.nc')
-    nco.ncks(input_file=foo_nc, output='bar.nc', wrt_tmp_fl=True)
-    nco.ncks(input_file=foo_nc, output='bar.nc', no_tmp_fl=True)
-    nco.ncks(input_file=foo_nc, output=foo_nc, no_tmp_fl=True, create_ram=True)
-    nco.ncks(input_file=foo_nc, output=foo_nc, no_tmp_fl=True, open_ram=True)
+    nco.ncks(input=foo_nc, output='bar.nc')
+    nco.ncks(input=foo_nc, output='bar.nc', wrt_tmp_fl=True)
+    nco.ncks(input=foo_nc, output='bar.nc', no_tmp_fl=True)
+    nco.ncks(input=foo_nc, output=foo_nc, no_tmp_fl=True, create_ram=True)
+    nco.ncks(input=foo_nc, output=foo_nc, no_tmp_fl=True, open_ram=True)
 
 
 def test_ncks_append_variables(foo_nc, bar_nc):
@@ -88,10 +88,10 @@ def test_ncks_append_variables(foo_nc, bar_nc):
     ncks -A fl_1.nc fl_2.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input_file=foo_nc, output=bar_nc, options=['-A'])
-    nco.ncks(input_file=foo_nc, output=bar_nc, append=True)
-    nco.ncks(input_file=foo_nc, output=bar_nc, apn=True)
-    nco.ncks(input_file=foo_nc, output=bar_nc)
+    nco.ncks(input=foo_nc, output=bar_nc, options=['-A'])
+    nco.ncks(input=foo_nc, output=bar_nc, append=True)
+    nco.ncks(input=foo_nc, output=bar_nc, apn=True)
+    nco.ncks(input=foo_nc, output=bar_nc)
 
 # def test_add_record_dimension():
 #     """
@@ -102,10 +102,10 @@ def test_ncks_append_variables(foo_nc, bar_nc):
 #     for idx in xrange(1, 11):
 #         infile = 'x_{:2}.nc'.format()
 #         outfile = 'foo_{:2}.nc'.format()
-#         nco.ncpdq(input_file=infile, output=outfile, arrange='x,time')
+#         nco.ncpdq(input=infile, output=outfile, arrange='x,time')
 #         outfiles.append(outfile)
-#     nco.ncrcat(input_file=outfiles, output='out.nc')
-#     nco.ncpdq(input_file='out.nc', output='out.nc', arrange='time,x')
+#     nco.ncrcat(input=outfiles, output='out.nc')
+#     nco.ncpdq(input='out.nc', output='out.nc', arrange='time,x')
 
 # def test_openMP_threading():
 #     pass
@@ -120,10 +120,10 @@ def test_command_line_options(foo_nc):
     ncks --dbg_lvl 3 in.nc # Long option, alternate form
     """
     nco = Nco(debug=True)
-    nco.ncks(input_file=foo_nc, options=['-O -D 3'])
-    nco.ncks(input_file=foo_nc, options=['-O --dbg_lvl=3'])
-    nco.ncks(input_file=foo_nc, options=['-O --dbg_lvl 3'])
-    # nco.ncks(input_file=foo_nc, dbg_lvl=3)
+    nco.ncks(input=foo_nc, options=['-O -D 3'])
+    nco.ncks(input=foo_nc, options=['-O --dbg_lvl=3'])
+    nco.ncks(input=foo_nc, options=['-O --dbg_lvl 3'])
+    # nco.ncks(input=foo_nc, dbg_lvl=3)
 
 
 def test_specifying_input_files(testfiles8589):
@@ -136,16 +136,16 @@ def test_specifying_input_files(testfiles8589):
     ncra -n 5,2,1 85.nc 8589.nc
     """
     nco = Nco(debug=True)
-    nco.ncra(input_file=testfiles8589, output='8589.nc')
-    nco.ncra(input_file=testfiles8589, output='8589.nc', nintap='5,2,1')
+    nco.ncra(input=testfiles8589, output='8589.nc')
+    nco.ncra(input=testfiles8589, output='8589.nc', nintap='5,2,1')
 
     srcdir = os.path.dirname(testfiles8589[0])
     basenames = [os.path.basename(x) for x in testfiles8589]
-    nco.ncra(input_file=basenames, output='8589.nc', path=srcdir)
+    nco.ncra(input=basenames, output='8589.nc', path=srcdir)
 
     # unable to use brackets, perhaps because we're no longer using shell=True when calling subprocess()?
     regpath = os.path.join(srcdir, '8[56789].nc')
-    nco.ncra(input_file=regpath, output='8589.nc', use_shell=True)
+    nco.ncra(input=regpath, output='8589.nc', use_shell=True)
 
 
 def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):
@@ -161,15 +161,15 @@ def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):
     ncks -D 2 -M foo_4.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input_file=foo3c, options=['-M'])
-    nco.ncks(input_file=foo364, options=['-M'])
-    nco.ncks(input_file=foo4c, options=['-M'])
-    nco.ncks(input_file=foo4c, options=['-D 2 -M'])
+    nco.ncks(input=foo3c, options=['-M'])
+    nco.ncks(input=foo364, options=['-M'])
+    nco.ncks(input=foo4c, options=['-M'])
+    nco.ncks(input=foo4c, options=['-D 2 -M'])
 
     if hdf_file is not None:
         assert os.path.isfile(hdf_file)
-        nco.ncks(input_file=hdf_file, options=['-D 2 -M'])
-    # nco.ncks(input_file='http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc',
+        nco.ncks(input=hdf_file, options=['-D 2 -M'])
+    # nco.ncks(input='http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc',
     #          options=['-D 2', '-M']) # does not work from command line either
 
 
@@ -191,18 +191,18 @@ def test_file_conversion(foo3c, foo4c):
     ncks --7 in.nc foo_4c.nc # netCDF4 classic
     """
     nco = Nco(debug=True)
-    nco.ncks(input_file=foo4c, output='foo_3c.nc', fl_fmt='classic')
-    nco.ncks(input_file=foo4c, output='foo_364.nc', fl_fmt='64bit')
-    nco.ncks(input_file=foo3c, output='foo_4c.nc', fl_fmt='netcdf4_classic')
-    nco.ncks(input_file=foo3c, output='foo_4.nc', fl_fmt='netcdf4')
-    nco.ncks(input_file=foo4c, output='foo_3c.nc', options=['-3'])
-    nco.ncks(input_file=foo4c, output='foo_3c.nc', options=['--3'])
-    nco.ncks(input_file=foo3c, output='foo_364c.nc', options=['-6'])
-    nco.ncks(input_file=foo3c, output='foo_364c.nc', options=['--64bit_offset'])
-    nco.ncks(input_file=foo3c, output='foo_4.nc', options=['-4'])
-    nco.ncks(input_file=foo3c, output='foo_4.nc', options=['--4'])
-    nco.ncks(input_file=foo3c, output='foo_4c.nc', options=['-7'])
-    nco.ncks(input_file=foo3c, output='foo_4c.nc', options=['--7'])
+    nco.ncks(input=foo4c, output='foo_3c.nc', fl_fmt='classic')
+    nco.ncks(input=foo4c, output='foo_364.nc', fl_fmt='64bit')
+    nco.ncks(input=foo3c, output='foo_4c.nc', fl_fmt='netcdf4_classic')
+    nco.ncks(input=foo3c, output='foo_4.nc', fl_fmt='netcdf4')
+    nco.ncks(input=foo4c, output='foo_3c.nc', options=['-3'])
+    nco.ncks(input=foo4c, output='foo_3c.nc', options=['--3'])
+    nco.ncks(input=foo3c, output='foo_364c.nc', options=['-6'])
+    nco.ncks(input=foo3c, output='foo_364c.nc', options=['--64bit_offset'])
+    nco.ncks(input=foo3c, output='foo_4.nc', options=['-4'])
+    nco.ncks(input=foo3c, output='foo_4.nc', options=['--4'])
+    nco.ncks(input=foo3c, output='foo_4c.nc', options=['-7'])
+    nco.ncks(input=foo3c, output='foo_4c.nc', options=['--7'])
 
 
 def test_hyperslabs(testfileglobal):
@@ -227,17 +227,17 @@ def test_hyperslabs(testfileglobal):
     ncks -F -d lon,-3, in.nc out.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,1,2')
-    nco.ncks(input_file=testfileglobal, output='out.nc',
+    nco.ncks(input=testfileglobal, output='out.nc',
              dimension='lon,1,2')
-    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,1.0,2.0')
-    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,0.0,90.0,2')
-    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,1,-2')
-    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,-3,-1')
-    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,-3')

--- a/tests/test_nco_examples.py
+++ b/tests/test_nco_examples.py
@@ -37,8 +37,8 @@ def test_ncks_hdf2nc(hdf_file):
     if hdf_file is None:
         pytest.skip('Skipped because h5py is not installed')
     nco = Nco(debug=True)
-    nco.ncks(input=hdf_file, output='foo.nc')
-    nco.ncks(input=hdf_file, output='foo.nc', hdf4=True)
+    nco.ncks(input_file=hdf_file, output='foo.nc')
+    nco.ncks(input_file=hdf_file, output='foo.nc', hdf4=True)
 
 
 def test_ncks_hdf2nc3(hdf_file):
@@ -56,10 +56,10 @@ def test_ncks_hdf2nc3(hdf_file):
     if hdf_file is None:
         pytest.skip('Skipped because h5py is not installed')
     nco = Nco(debug=True)
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-3'])
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-7 -L 1'])
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-3'], hdf4=True)
-    nco.ncks(input=hdf_file, output='foo.nc', options=['-7'], hdf4=True)
+    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-3'])
+    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-7 -L 1'])
+    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-3'], hdf4=True)
+    nco.ncks(input_file=hdf_file, output='foo.nc', options=['-7'], hdf4=True)
 
 
 def test_temp_output_files(foo_nc):
@@ -73,11 +73,11 @@ def test_temp_output_files(foo_nc):
     ncks --open_ram --no_tmp_fl in.nc in.nc # Read into RAM, write to disk
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo_nc, output='bar.nc')
-    nco.ncks(input=foo_nc, output='bar.nc', wrt_tmp_fl=True)
-    nco.ncks(input=foo_nc, output='bar.nc', no_tmp_fl=True)
-    nco.ncks(input=foo_nc, output=foo_nc, no_tmp_fl=True, create_ram=True)
-    nco.ncks(input=foo_nc, output=foo_nc, no_tmp_fl=True, open_ram=True)
+    nco.ncks(input_file=foo_nc, output='bar.nc')
+    nco.ncks(input_file=foo_nc, output='bar.nc', wrt_tmp_fl=True)
+    nco.ncks(input_file=foo_nc, output='bar.nc', no_tmp_fl=True)
+    nco.ncks(input_file=foo_nc, output=foo_nc, no_tmp_fl=True, create_ram=True)
+    nco.ncks(input_file=foo_nc, output=foo_nc, no_tmp_fl=True, open_ram=True)
 
 
 def test_ncks_append_variables(foo_nc, bar_nc):
@@ -88,10 +88,10 @@ def test_ncks_append_variables(foo_nc, bar_nc):
     ncks -A fl_1.nc fl_2.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo_nc, output=bar_nc, options=['-A'])
-    nco.ncks(input=foo_nc, output=bar_nc, append=True)
-    nco.ncks(input=foo_nc, output=bar_nc, apn=True)
-    nco.ncks(input=foo_nc, output=bar_nc)
+    nco.ncks(input_file=foo_nc, output=bar_nc, options=['-A'])
+    nco.ncks(input_file=foo_nc, output=bar_nc, append=True)
+    nco.ncks(input_file=foo_nc, output=bar_nc, apn=True)
+    nco.ncks(input_file=foo_nc, output=bar_nc)
 
 # def test_add_record_dimension():
 #     """
@@ -102,10 +102,10 @@ def test_ncks_append_variables(foo_nc, bar_nc):
 #     for idx in xrange(1, 11):
 #         infile = 'x_{:2}.nc'.format()
 #         outfile = 'foo_{:2}.nc'.format()
-#         nco.ncpdq(input=infile, output=outfile, arrange='x,time')
+#         nco.ncpdq(input_file=infile, output=outfile, arrange='x,time')
 #         outfiles.append(outfile)
-#     nco.ncrcat(input=outfiles, output='out.nc')
-#     nco.ncpdq(input='out.nc', output='out.nc', arrange='time,x')
+#     nco.ncrcat(input_file=outfiles, output='out.nc')
+#     nco.ncpdq(input_file='out.nc', output='out.nc', arrange='time,x')
 
 # def test_openMP_threading():
 #     pass
@@ -120,10 +120,10 @@ def test_command_line_options(foo_nc):
     ncks --dbg_lvl 3 in.nc # Long option, alternate form
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo_nc, options=['-D 3'])
-    nco.ncks(input=foo_nc, options=['--dbg_lvl=3'])
-    nco.ncks(input=foo_nc, options=['--dbg_lvl 3'])
-    nco.ncks(input=foo_nc, dbg_lvl=3)
+    nco.ncks(input_file=foo_nc, options=['-O -D 3'])
+    nco.ncks(input_file=foo_nc, options=['-O --dbg_lvl=3'])
+    nco.ncks(input_file=foo_nc, options=['-O --dbg_lvl 3'])
+    # nco.ncks(input_file=foo_nc, dbg_lvl=3)
 
 
 def test_specifying_input_files(testfiles8589):
@@ -136,15 +136,16 @@ def test_specifying_input_files(testfiles8589):
     ncra -n 5,2,1 85.nc 8589.nc
     """
     nco = Nco(debug=True)
-    nco.ncra(input=testfiles8589, output='8589.nc')
-    nco.ncra(input=testfiles8589, output='8589.nc', nintap='5,2,1')
+    nco.ncra(input_file=testfiles8589, output='8589.nc')
+    nco.ncra(input_file=testfiles8589, output='8589.nc', nintap='5,2,1')
 
     srcdir = os.path.dirname(testfiles8589[0])
-    basenames = [ os.path.basename(x) for x in testfiles8589 ]
-    nco.ncra(input=basenames, output='8589.nc', path=srcdir)
+    basenames = [os.path.basename(x) for x in testfiles8589]
+    nco.ncra(input_file=basenames, output='8589.nc', path=srcdir)
 
-    regpath = os.path.join(srcdir, '8[56789].nc')
-    nco.ncra(input=regpath, output='8589.nc')
+    # unable to use brackets, perhaps because we're no longer using shell=True when calling subprocess()?
+    # regpath = os.path.join(srcdir, '8[56789].nc')
+    # nco.ncra(input_file="f\"" + regpath + "\"", output='8589.nc')
 
 
 def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):
@@ -160,15 +161,15 @@ def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):
     ncks -D 2 -M foo_4.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo3c, options=['-M'])
-    nco.ncks(input=foo364, options=['-M'])
-    nco.ncks(input=foo4c, options=['-M'])
-    nco.ncks(input=foo4c, options=['-D 2 -M'])
+    nco.ncks(input_file=foo3c, options=['-M'])
+    nco.ncks(input_file=foo364, options=['-M'])
+    nco.ncks(input_file=foo4c, options=['-M'])
+    nco.ncks(input_file=foo4c, options=['-D 2 -M'])
 
     if hdf_file is not None:
         assert os.path.isfile(hdf_file)
-        nco.ncks(input=hdf_file, options=['-D 2 -M'])
-    # nco.ncks(input='http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc',
+        nco.ncks(input_file=hdf_file, options=['-D 2 -M'])
+    # nco.ncks(input_file='http://thredds-test.ucar.edu/thredds/dodsC/testdods/in.nc',
     #          options=['-D 2', '-M']) # does not work from command line either
 
 
@@ -190,18 +191,18 @@ def test_file_conversion(foo3c, foo4c):
     ncks --7 in.nc foo_4c.nc # netCDF4 classic
     """
     nco = Nco(debug=True)
-    nco.ncks(input=foo4c, output='foo_3c.nc', fl_fmt='classic')
-    nco.ncks(input=foo4c, output='foo_364.nc', fl_fmt='64bit')
-    nco.ncks(input=foo3c, output='foo_4c.nc', fl_fmt='netcdf4_classic')
-    nco.ncks(input=foo3c, output='foo_4.nc', fl_fmt='netcdf4')
-    nco.ncks(input=foo4c, output='foo_3c.nc', options=['-3'])
-    nco.ncks(input=foo4c, output='foo_3c.nc', options=['--3'])
-    nco.ncks(input=foo3c, output='foo_364c.nc', options=['-6'])
-    nco.ncks(input=foo3c, output='foo_364c.nc', options=['--64bit_offset'])
-    nco.ncks(input=foo3c, output='foo_4.nc', options=['-4'])
-    nco.ncks(input=foo3c, output='foo_4.nc', options=['--4'])
-    nco.ncks(input=foo3c, output='foo_4c.nc', options=['-7'])
-    nco.ncks(input=foo3c, output='foo_4c.nc', options=['--7'])
+    nco.ncks(input_file=foo4c, output='foo_3c.nc', fl_fmt='classic')
+    nco.ncks(input_file=foo4c, output='foo_364.nc', fl_fmt='64bit')
+    nco.ncks(input_file=foo3c, output='foo_4c.nc', fl_fmt='netcdf4_classic')
+    nco.ncks(input_file=foo3c, output='foo_4.nc', fl_fmt='netcdf4')
+    nco.ncks(input_file=foo4c, output='foo_3c.nc', options=['-3'])
+    nco.ncks(input_file=foo4c, output='foo_3c.nc', options=['--3'])
+    nco.ncks(input_file=foo3c, output='foo_364c.nc', options=['-6'])
+    nco.ncks(input_file=foo3c, output='foo_364c.nc', options=['--64bit_offset'])
+    nco.ncks(input_file=foo3c, output='foo_4.nc', options=['-4'])
+    nco.ncks(input_file=foo3c, output='foo_4.nc', options=['--4'])
+    nco.ncks(input_file=foo3c, output='foo_4c.nc', options=['-7'])
+    nco.ncks(input_file=foo3c, output='foo_4c.nc', options=['--7'])
 
 
 def test_hyperslabs(testfileglobal):
@@ -226,17 +227,17 @@ def test_hyperslabs(testfileglobal):
     ncks -F -d lon,-3, in.nc out.nc
     """
     nco = Nco(debug=True)
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,1,2')
-    nco.ncks(input=testfileglobal, output='out.nc',
+    nco.ncks(input_file=testfileglobal, output='out.nc',
              dimension='lon,1,2')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,1.0,2.0')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,0.0,90.0,2')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,1,-2')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,-3,-1')
-    nco.ncks(input=testfileglobal, output='out.nc', fortran=True,
+    nco.ncks(input_file=testfileglobal, output='out.nc', fortran=True,
              dimension='lon,-3')

--- a/tests/test_nco_examples.py
+++ b/tests/test_nco_examples.py
@@ -144,8 +144,8 @@ def test_specifying_input_files(testfiles8589):
     nco.ncra(input_file=basenames, output='8589.nc', path=srcdir)
 
     # unable to use brackets, perhaps because we're no longer using shell=True when calling subprocess()?
-    # regpath = os.path.join(srcdir, '8[56789].nc')
-    # nco.ncra(input_file="f\"" + regpath + "\"", output='8589.nc')
+    regpath = os.path.join(srcdir, '8[56789].nc')
+    nco.ncra(input_file=regpath, output='8589.nc', use_shell=True)
 
 
 def test_determining_file_format(foo3c, foo364, foo4c, hdf_file):


### PR DESCRIPTION
Some updates to resolve #37, still some clean up left to do to sort out leftover code that is in place (I think) to handle temporary files (I left it alone, not certain yet of its purpose and/or if working in any way, but it doesn't appear to be). Some tests are commented out since functionality has been reduced, e.g. we're no longer able to pass brackets in input file and have the shell expand these since we've eliminated shell=True (a security vulnerability mentioned in #33) -- not sure if this is a deal breaker, if so then it may not be too tricky to accommodate.

All tests pass now (several were broken) and the code is working well when used in a [script](https://github.com/monocongo/climate_indices/blob/master/scripts/process_grid_ufunc.py#L864) where I use a temporary file with `ncpdq`.