### PR TITLE
Fix handling of whitespace in command line arguments

### DIFF
--- a/nco/custom.py
+++ b/nco/custom.py
@@ -232,9 +232,10 @@ class Atted(object):
         # modeChar=VALID_MODES[self.mode]
         # deal with delete - nb doesnt need any data
         if self.mode == "d":
-            return '-a "{0}","{1}",{2},,'.format(
-                self.att_name, self.var_name, self.mode
-            )
+            return [
+                '-a',
+                '{0},{1},{2},,'.format(self.att_name, self.var_name, self.mode),
+            ]
 
         bList = isinstance(self.np_value, (list, np.ndarray))
 
@@ -253,17 +254,15 @@ class Atted(object):
         if not bList:
             self.np_value = [self.np_value]
 
-        # if isinstance(self.np_type, str):
-        if self.np_type is str:
-            strArray = ['"' + str(v) + '"' for v in self.np_value]
-        else:
-            strArray = [str(v) for v in self.np_value]
-
+        strArray = [str(v) for v in self.np_value]
         strvalue = ",".join(strArray)
 
-        return '-a "{0}","{1}",{2},{3},{4}'.format(
-            self.att_name, self.var_name, self.mode, type_char, strvalue
-        )
+        return [
+            '-a',
+            '{0},{1},{2},{3},{4}'.format(
+                self.att_name, self.var_name, self.mode, type_char, strvalue
+            ),
+        ]
 
 
 class Limit(object):
@@ -317,18 +316,13 @@ class Limit(object):
         )
 
     def prn_option(self):
-        bstr = '-d "{0}",{1},{2}'.format(self.dmn_name, self.srt, self.end)
-
-        if self.drn != "":
-            estr = ",{0},{1}".format(self.srd, self.drn)
-        elif self.srd != "":
-            estr = ",{0}".format(self.srd)
-        else:
-            estr = ""
-
-        bstr += estr
-
-        return bstr
+        bits = [self.dmn_name, self.srt, self.end]
+        if self.drn != '':
+            bits.append(self.srd)
+            bits.append(self.drn)
+        elif self.srd != '':
+            bits.append(self.srd)
+        return ['-d', ",".join(map(str, bits))]
 
 
 class LimitSingle(Limit):
@@ -350,9 +344,7 @@ class LimitSingle(Limit):
         Override of the base method in Limit.
         This just prints the "srt" index
         """
-        bstr = '-d "{0}",{1}'.format(self.dmn_name, self.srt)
-
-        return bstr
+        return ['-d', '{0},{1}'.format(self.dmn_name, self.srt)]
 
 
 class Rename(object):
@@ -381,11 +373,12 @@ class Rename(object):
         self.rDict = rdict
 
     def prn_option(self):
+        options = []
 
-        lout = []
         for (sKey, Value) in self.rDict.items():
-            sf = '-{0} "{1}","{2}"'.format(self.rtype, sKey, Value)
-            lout.append(sf)
+            options.extend([
+                '-{0}'.format(self.rtype),
+                '{0},{1}'.format(sKey, Value),
+            ])
 
-        sout = " ".join(lout)
-        return sout
+        return options

--- a/nco/nco.py
+++ b/nco/nco.py
@@ -2,8 +2,9 @@
 nco module.  Use Nco class as interface.
 """
 import distutils.spawn
-import os
+import os.path
 import re
+import shlex
 import subprocess
 import tempfile
 
@@ -119,7 +120,7 @@ class Nco(object):
             if environment:
                 for key, val in list(environment.items()):
                     print("# DEBUG: ENV: {0} = {1}".format(key, val))
-            print("# DEBUG: CALL>> {0}".format(" ".join(inline_cmd)))
+            print("# DEBUG: CALL>> {0}".format(" ".join(map(shlex.quote, inline_cmd))))
             print("# DEBUG ==================================================")
 
         # if we're using the shell then we need to pass a single string as the
@@ -193,7 +194,7 @@ class Nco(object):
             return_array = kwargs.pop("returnArray", False)
             return_ma_array = kwargs.pop("returnMaArray", False)
             operator_prints_out = kwargs.pop("operator_prints_out", False)
-            use_shell = kwargs.pop("use_shell", True)
+            use_shell = kwargs.pop("use_shell", False)
 
             # build the NCO command
             # 1. the NCO operator
@@ -202,9 +203,9 @@ class Nco(object):
             if options:
                 for option in options:
                     if isinstance(option, str):
-                        cmd.extend(str.split(option))
+                        cmd.extend(shlex.split(option))
                     elif hasattr(option, "prn_option"):
-                        cmd.extend(option.prn_option().split())
+                        cmd.extend(option.prn_option())
                     else:
                         # assume it's an iterable
                         cmd.extend(option)
@@ -320,7 +321,7 @@ class Nco(object):
                 elif not (nco_command in self.SingleFileOperatorsPattern):
                     # create a temporary file, use this as the output
                     file_name_prefix = (
-                        nco_command + "_" + input.split(os.sep)[-1]
+                        nco_command + "_" + os.path.basename(input)
                     )
                     tmp_file = tempfile.NamedTemporaryFile(
                         mode="w+b",


### PR DESCRIPTION
In the current code base the `Atted.prn_option()`, `Limit.prn_option()`, `LimitSingle.prn_option()` functions all returned a single string containing a command line flag and its argument. The `Nco` alias functions such as `Nco.ncatted()` will call the `prn_option()` method on any option passed in and then split the string on whitespace in to its component arguments and flags. This behaviour leads to bugs when there is whitespace in the argument values:

```python
>>> from nco.custom import Atted
>>> atted = Atted(
...     action='create', var_name='lon', att_name='long_name',
...     value='longitude coordinate'
... )
>>> atted.prn_option()
'-a "long_name","lon",o,c,"longitude coordinate"'
>>> atted.prn_option().split()
['-a', '"long_name","lon",o,c,"longitude', 'coordinate"']
```

This bug was worked around by calling functions with `use_shell=True`, which recently became the default. When using the shell the arguments were joined back together with `' '.join(cmd)`. This reversed the previous split and made a working command line again. This behaviour does not work if command line values have quotes in them - especially if those quotes are unbalanced. The quotes are not escaped and will be interpreted by the shell.

[`shlex.split()`](https://docs.python.org/3/library/shlex.html#shlex.split) can correctly split strings containing quoted whitespace. [`shlex.quote()`](https://docs.python.org/3/library/shlex.html#shlex.quote) can add required quotes and escape sequences to any word that should be considered a single command line argument. [`shlex.join()`](https://docs.python.org/3/library/shlex.html#shlex.join) is the opposite of `shlex.split()` but was only added in Python 3.8. `shlex.join` can be emulated with `' '.join(map(shlex.quote, arguments))`

```python
>>> shlex.split(atted.prn_option())
['-a', 'long_name,lon,o,sng,longitude coordinate']
>>> description = 'Longitude values are often formatted using the symbols ° \' "'
>>> ' '.join(map(shlex.quote, ['-a', 'description,lon,o,sng,' + description]))
'-a \'description,lon,o,sng,Longitude values are often formatted using the symbols ° \'"\'"\' "\''
```

This pull requests makes two changes to the handling of whitespace. First, it uses the `shlex` module for all joining and splitting of command line flags and arguments. Secondly, it changes the `prn_option()` methods to return lists of arguments instead of a string that needs splitting. This simplifies the code on each side. `subprocess.Popen()` correctly handles whitespace in arguments, so by keeping the `prn_option()` output as an array, no special handling of whitespace is required.

I have added a test for `Nco.ncatted()` that adds some attributes and values with whitespace and quotes in the names. The output dataset is then examined using the `netCDF4` module to ensure the new attributes were added correctly.