### PR TITLE
Use `stdin=DEVNULL` when running subprocesses

### DIFF
--- a/nco/nco.py
+++ b/nco/nco.py
@@ -130,6 +130,7 @@ class Nco(object):
                 proc = subprocess.Popen(
                     shell_cmd,
                     shell=True,
+                    stdin=subprocess.DEVNULL,
                     stderr=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     env=environment,
@@ -141,6 +142,7 @@ class Nco(object):
         if not use_shell:
             proc = subprocess.Popen(
                 cmd,
+                stdin=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 env=environment,

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -3,7 +3,9 @@ Unit tests for nco.py.
 """
 import distutils.spawn
 import os
-from unittest.mock import MagicMock
+import subprocess
+from functools import partial
+from unittest.mock import MagicMock, patch
 
 import netCDF4
 import numpy as np
@@ -112,6 +114,38 @@ def test_ncea_mult_files(foo_nc, bar_nc):
     nco = Nco(debug=True)
     infiles = [foo_nc, bar_nc]
     nco.ncea(input=infiles, output="out.nc")
+
+
+def test_overwrite_existing_file(foo_nc, tmp_path, monkeypatch):
+    """
+    By default the nco tools will prompt the user before overwriting a file.
+    The output of all commands is collected by pynco
+    so the user will never see the prompt.
+    This can result in `nco.ncatted` etc hanging indefinitely waiting for input
+    that will never come.
+    """
+    outfile = str(tmp_path / 'out.nc')
+    with open(outfile, 'w') as f:
+        f.write('boop')
+
+    # Monkeypatch `Popen.communicate` to have a default timeout value
+    # so that a failed test here doesn't cause the test suite to hang.
+    class PopenTimeout(subprocess.Popen):
+        def communicate(self, *args, timeout=2, **kwargs):
+            return super().communicate(*args, timeout=timeout, **kwargs)
+
+    monkeypatch.setattr(subprocess, 'Popen', PopenTimeout)
+
+    # Disable forced overwriting of files to expose this potential issue.
+    # This method is one of many.
+    nco = Nco(debug=True, force_output=False)
+    with pytest.raises(NCOException):
+        # This should fail with an NCOException because the tool aborted when
+        # it did not get user input.
+        # The test fails if a subprocess.TimeoutExpired exception is raised.
+        nco.ncatted(input=foo_nc, output=outfile, options=[
+            '-a', 'att_name,time,o,c,value',
+        ])
 
 
 def test_error_exception():

--- a/tests/test_nco.py
+++ b/tests/test_nco.py
@@ -4,8 +4,6 @@ Unit tests for nco.py.
 import distutils.spawn
 import os
 import subprocess
-from functools import partial
-from unittest.mock import MagicMock, patch
 
 import netCDF4
 import numpy as np


### PR DESCRIPTION
Some nco tools would prompt for user input. This could happen if the output file already existed and `--overwrite` was not passed (or passed twice, although this bug has been fixed in `nco` itself). Because of how the process was invoked, no input on stdin could ever be provided, and the output of the process was not printed to any console or log until after the process finished. This caused `pynco` to freeze waiting for input, with no feedback to the user or calling process.

This PR closes `stdin` when calling `nco` executables. When the tools prompt for user input, they will abort due to getting no response. This will cause the `nco` call to fail, but an error is better than an indefinite hang!

Fixes #56